### PR TITLE
fixing black horizon issue on shuto c1 track

### DIFF
--- a/config/tracks/c1.ini
+++ b/config/tracks/c1.ini
@@ -1,5 +1,5 @@
 [SHADER_REPLACEMENT_...]
-MATERIALS = horizon
+MATERIALS = horizon, horizon1, horizon3, horizon5
 BLEND_MODE = ALPHA_TEST
 
 [SHADER_REPLACEMENT_...]


### PR DESCRIPTION
@gro-ove @RustyChest I've manage to fix https://github.com/ac-custom-shaders-patch/acc-extension-config/issues/30 myself, I grepped the kn5 files for the word 'horizon' and it turns out there were multiple billboard objects with the prefix 'horizon' in their names. Adding all these to the `MATERIALS` list solves the issue.

@gro-ove that second issue I reported (https://github.com/ac-custom-shaders-patch/acc-extension-config/issues/30#issuecomment-604178539), with the blinking black shadows when inside tunnels, is still present I'm afraid.