### PR TITLE
Added config for URD PX2 Loire (Oreca O5).

### DIFF
--- a/config/cars/mods/urd/urd_px2_loire.ini
+++ b/config/cars/mods/urd/urd_px2_loire.ini
@@ -3,18 +3,27 @@
 ; Major features different from the "guessed" values:
 ; - instrument panel lights up with headlights
 ; - dashboard labels light up with headlights
+; - cockpit softly illuminates with headlights
 ; - brake lights are now explicitly defined
 ; - "legality panel" brake lights now light up (sort of)
 ; - "legality panel" lights now illuminate with headlights
+;
+; Reference videos:
+; - https://youtu.be/wot-fRRjkJ8?t=277
+; - https://youtu.be/6f48FuCDnSY
 
-; brake/tail lights must be defined as CustomEmissives
+[INCLUDE: common/no_popup_lights.ini]
+
 [INCLUDE: common/custom_emissive.ini]
+[DEFAULTS]
+ParkingLightsLag = 0.0
+BrakingLightsLag = 0.0
 
 [EMISSIVE_LIGHT_...]
 ; changes instrument panel glow to link with headlights
 NAME=rpx1_sw_ads
 BIND_TO_HEADLIGHTS=1
-COLOR=0.6,0.6,1,1.0
+COLOR=0.5,0.5,1,1.0
 EXTERIOR_ONLY=0
 INTERIOR_ONLY=1
 LAG=0
@@ -40,15 +49,31 @@ OFF_MULT=0
 EXTERIOR_ONLY=0
 INTERIOR_ONLY=1
 
-[LIGHT_BRAKE_...]
-; Explicit definition for top brake lights (on wing)
+[CustomEmissiveMulti]
+; Wing light bar "glow" for BOTH taillights and brake lights.
+; Compare to this recap of the 2016 Le Mans race:
+;   https://youtu.be/wot-fRRjkJ8?t=277
+; The real-life Oreca O5s don't seem to agree on which section
+; should be the taillights. I've chosen the top section.
+Meshes = Brake_Lights
+Resolution = 2048, 2048
+; Illuminate only the top section for the tail lights.
+;@ = MultiItem, Role = ParkingLights, Center = "61, 318", Size = "46, 600", CornerRadius = 0, Exponent = 0.1, Color = "1, 0, 0", Intensity = 128, Location = "REAR"
+; Illuminate only the bottom section for the tail lights.
+@ = MultiItem, Role = ParkingLights, Center = "139, 318", Size = "46, 600", CornerRadius = 0, Exponent = 0.1, Color = "1, 0, 0", Intensity = 128, Location = "REAR", Lag = 0, HeatingMult = 0
+; Illuminate both top and bottom sections for brake lights.
+@ = MultiItem, Role = BrakingLights, Center = "102, 318", Size = "132, 600", CornerRadius = 0, Exponent = 0.1, Color = "2, 0.01, 0.01", Intensity = 256, Location = "REAR", Lag = 0, HeatingMult = 0
+
+[LIGHT_EXTRA_...]
+; Explicit definition of beams for wing light bars.
 ; Similar to the auto-guess but with some tweaks.
 AFFECTS_TRACK=1
+BIND_TO_BRAKELIGHTS=1
 COLOR=1,0,0,3
 DIFFUSE_CONCENTRATION=0.88
-DIRECTION=0,0,-1
+DIRECTION=0,-0.5,-1
 EXTERIOR_ONLY=1
-FADE_AT=120
+FADE_AT=160
 FADE_SMOOTH=30
 INTERIOR_ONLY=0
 LAG=0
@@ -60,15 +85,24 @@ OFF_MULT=0
 POSITION=0, 0.932092, -2.3
 RANGE=10
 RANGE_GRADIENT_OFFSET=0.25
-SPOT=160
+SPOT=75
 SPOT_EDGE=0.34,0.34,0.34
 SPOT_EDGE_SHARPNESS=10
 SPOT_SHARPNESS=0.375
 
-[LIGHT_BRAKE_...]
+[CustomEmissiveMulti]
+; Legality panel "glow" for BOTH taillights and brake lights.
+; Unfortunately this also lights up the P3 indicator.
+Meshes = rpx2_body_misc_a_SUB2
+Resolution = 1024, 1024
+@ = MultiItem, Role = ParkingLights, Center = "46, 311", Size = 80, CornerRadius = 1, Exponent = 0.1, Color = "1, 0, 0", Intensity = 20, Location = "REAR"
+@ = MultiItem, Role = BrakingLights, Center = "46, 311", Size = 80, CornerRadius = 1, Exponent = 0.1, Color = "1, 0, 0", Intensity = 75, Location = "REAR"
+
+[LIGHT_EXTRA_...]
 ; Legality panel beams for brake lights.
 ; Positioned to appear as if they come from the light textures.
 AFFECTS_TRACK=1
+BIND_TO_BRAKELIGHTS=1
 COLOR=1,0,0,5
 DIFFUSE_CONCENTRATION=0.88
 DIRECTION=0,0,-1
@@ -81,7 +115,7 @@ LOCATION=REAR
 MIRROR=0.606
 NO_SELF_SPECULAR=1
 OFF_MULT=0
-POSITION=0, 0.14, -2.30
+POSITION=0, 0.1435, -2.32
 RANGE=5
 RANGE_GRADIENT_OFFSET=0.25
 SPOT=45
@@ -107,7 +141,7 @@ LOCATION=REAR
 MIRROR=0.606
 NO_SELF_SPECULAR=1
 OFF_MULT=0
-POSITION=0, 0.14, -2.30
+POSITION=0, 0.1435, -2.32
 RANGE=5
 RANGE_GRADIENT_OFFSET=0.25
 SPOT=45
@@ -115,10 +149,22 @@ SPOT_EDGE=0.34,0.34,0.34
 SPOT_EDGE_SHARPNESS=10
 SPOT_SHARPNESS=0.250
 
-[CustomEmissiveMulti]
-; Legality panel "glow" for BOTH taillights and brake lights.
-; Unfortunately this also lights up the P3 indicator.
-Meshes = rpx2_body_misc_a_SUB2
-Resolution = 1024, 1024
-@ = MultiItem, Role = ParkingLights, Center = "46, 311", Size = 80, CornerRadius = 1, Exponent = 0.1, Color = "1, 0, 0", Intensity = 5, Location = "REAR"
-@ = MultiItem, Role = BrakingLights, Center = "46, 311", Size = 80, CornerRadius = 1, Exponent = 0.1, Color = "1, 0, 0", Intensity = 7, Location = "REAR"
+[LIGHT_EXTRA_...]
+; Cockpit lighting while headlights are on.
+; Compare this on-board footage of the real car.
+; https://www.youtube.com/watch?v=6f48FuCDnSY
+AFFECTS_TRACK=1
+BIND_TO_HEADLIGHTS=1
+COLOR=0.20,0.1,1,2
+DIRECTION=0,-1,1
+DIFFUSE_CONCENTRATION=0.88
+EXTERIOR_ONLY=0
+FADE_AT=2
+FADE_SMOOTH=20
+INTERIOR_ONLY=0
+LAG=0
+NO_SELF_SPECULAR=1
+OFF_MULT=0
+POSITION=0,1,0
+RANGE=1.5
+SPOT=60

--- a/config/cars/mods/urd/urd_px2_loire.ini
+++ b/config/cars/mods/urd/urd_px2_loire.ini
@@ -1,0 +1,171 @@
+; Custom Shaders Patch config for URD PX2 Loire (Oreca O5)
+;
+; Major features different from the "guessed" values:
+; - instrument panel lights up with headlights
+; - dashboard labels light up with headlights
+; - brake lights are now explicitly defined
+; - "legality panel" brake lights now light up (sort of)
+; - "legality panel" lights now illuminate with headlights
+;
+; The "glow" effects for the rear diffuser "legality panel"
+; are achieved in a hacky way by shining actual light effects
+; forward toward the appropriate spots on the car. We can't
+; simply use an EMISSIVE like we should, because URD didn'tail
+; define those LED-like elements as their own object in the
+; car model. If you assign an emissive to one of the parts near
+; the lights, you either light up the windows, or the chassis.
+; So we get to use this hack instead.
+; The "right" fix would be to include a .kn5 patch that defines
+; some LED-like objects in the model, and then change this file
+; to light those up appropriately.
+
+[EMISSIVE_LIGHT_...]
+; changes instrument panel glow to link with headlights
+NAME=rpx1_sw_ads
+BIND_TO_HEADLIGHTS=1
+COLOR=0.6,0.6,1,1.5
+EXTERIOR_ONLY=0
+INTERIOR_ONLY=1
+LAG=0
+OFF_COLOR=1,1,1,0.6
+
+[EMISSIVE_LIGHT_...]
+; steering wheel labels glow with headlights
+NAME=rpx1_sw_badges
+BIND_TO_HEADLIGHTS=1
+COLOR=0.8,1,0.2,0.5
+LAG=0
+OFF_COLOR=0
+EXTERIOR_ONLY=0
+INTERIOR_ONLY=1
+
+[EMISSIVE_LIGHT_...]
+; dashboard labels glow with headlights
+NAME=rpx1_cockpit_badges
+BIND_TO_HEADLIGHTS=1
+COLOR=0.8,1,0.2,0.5
+LAG=0
+OFF_MULT=0
+EXTERIOR_ONLY=0
+INTERIOR_ONLY=1
+
+[LIGHT_BRAKE_...]
+; top brake lights
+; similar to the auto-guess but with some tweaks
+NAME=Brake_Lights
+AFFECTS_TRACK=1
+COLOR=1,0,0,2
+DIFFUSE_CONCENTRATION=0.88
+DIRECTION=0,0,-1
+EXTERIOR_ONLY=1
+FADE_AT=120
+FADE_SMOOTH=30
+INTERIOR_ONLY=0
+LAG=0
+LOCATION=REAR
+NO_SELF_SPECULAR=1
+OFF_MULT=0
+RANGE=10
+RANGE_GRADIENT_OFFSET=0.25
+SPOT=160
+SPOT_EDGE=0.34,0.34,0.34
+SPOT_EDGE_SHARPNESS=10
+SPOT_SHARPNESS=0.375
+
+[LIGHT_BRAKE_...]
+; legality panel brake light beam
+AFFECTS_TRACK=1
+COLOR=1,0,0,2
+DIFFUSE_CONCENTRATION=0.88
+DIRECTION=0,0,-1
+EXTERIOR_ONLY=1
+FADE_AT=80
+FADE_SMOOTH=20
+INTERIOR_ONLY=0
+LAG=0
+LOCATION=REAR
+MIRROR=0.615
+NO_SELF_SPECULAR=1
+OFF_MULT=0
+POSITION=0, 0.13, -2.13
+RANGE=5
+RANGE_GRADIENT_OFFSET=0.25
+SPOT=45
+SPOT_EDGE=0.34,0.34,0.34
+SPOT_EDGE_SHARPNESS=10
+SPOT_SHARPNESS=0.250
+
+[LIGHT_BRAKE_...]
+; legality panel brake light glow
+; This is a bit of a hack. See comments at top of file.
+AFFECTS_TRACK=1
+COLOR=1,0,0,10
+DIFFUSE_CONCENTRATION=0.25
+DIRECTION=0,0,1
+EXTERIOR_ONLY=1
+FADE_AT=80
+FADE_SMOOTH=0.9
+INTERIOR_ONLY=0
+LAG=0
+LOCATION=REAR
+MIRROR=0.606
+NO_SELF_SPECULAR=1
+OFF_MULT=0
+POSITION=0, 0.145, -2.39
+RANGE=0.8
+RANGE_GRADIENT_OFFSET=0.01
+SPOT=45
+SPOT_EDGE=1,1,1
+SPOT_EDGE_SHARPNESS=0.75
+SPOT_SHARPNESS=1
+
+[LIGHT_EXTRA_...]
+; legality panel tail light beams with headlights
+; This is essentially a copy of the brake light beams above.
+AFFECTS_TRACK=1
+BIND_TO_HEADLIGHTS=1
+COLOR=1,0,0,1
+DIFFUSE_CONCENTRATION=0.88
+DIRECTION=0,0,-1
+EXTERIOR_ONLY=1
+FADE_AT=80
+FADE_SMOOTH=20
+INTERIOR_ONLY=0
+LAG=0
+LOCATION=REAR
+MIRROR=0.615
+NO_SELF_SPECULAR=1
+OFF_MULT=0
+POSITION=0, 0.13, -2.13
+RANGE=5
+RANGE_GRADIENT_OFFSET=0.25
+SPOT=45
+SPOT_EDGE=0.34,0.34,0.34
+SPOT_EDGE_SHARPNESS=10
+SPOT_SHARPNESS=0.250
+
+[LIGHT_EXTRA_...]
+; legality panel tail light glow with headlights
+; This is a bit of a hack. See comments at top of file.
+; This is essentially a copy of the brake light glow above.
+AFFECTS_TRACK=1
+BIND_TO_HEADLIGHTS=1
+COLOR=1,0,0,6 
+DIFFUSE_CONCENTRATION=0.25
+DIRECTION=0,0,1
+EXTERIOR_ONLY=1
+FADE_AT=80
+FADE_SMOOTH=0.9
+INTERIOR_ONLY=0
+LAG=0
+LOCATION=REAR
+MIRROR=0.606
+NO_SELF_SPECULAR=1
+OFF_MULT=0
+POSITION=0, 0.145, -2.39
+RANGE=0.8
+RANGE_GRADIENT_OFFSET=0.01
+SPOT=45
+SPOT_EDGE=1,1,1
+SPOT_EDGE_SHARPNESS=0.75
+SPOT_SHARPNESS=1

--- a/config/cars/mods/urd/urd_px2_loire.ini
+++ b/config/cars/mods/urd/urd_px2_loire.ini
@@ -7,6 +7,7 @@
 ; - brake lights are now explicitly defined
 ; - "legality panel" brake lights now light up (sort of)
 ; - "legality panel" lights now illuminate with headlights
+; - corrected headlights
 ;
 ; Reference videos:
 ; - https://youtu.be/wot-fRRjkJ8?t=277
@@ -18,6 +19,21 @@
 [DEFAULTS]
 ParkingLightsLag = 0.0
 BrakingLightsLag = 0.0
+
+[DATA]
+LIGHT_HEATING_K_Brake_Lights=0
+LIGHT_HEATING_K_Head_Lights=0
+
+[EMISSIVE_LIGHT_0]
+; Recolors the headlight glow.
+NAME=Head_Lights
+ACT_AS_HEADLIGHTS=1
+BIND_TO_HEADLIGHTS=1
+CAST_LIGHT=1
+COLOR=1.0, 0.95, 0.75, 512
+EXTERIOR_ONLY=0
+INTERIOR_ONLY=0
+LAG=0
 
 [EMISSIVE_LIGHT_...]
 ; changes instrument panel glow to link with headlights
@@ -49,6 +65,10 @@ OFF_MULT=0
 EXTERIOR_ONLY=0
 INTERIOR_ONLY=1
 
+[LIGHT_HEADLIGHT_0]
+; Replaces the auto-guessed headlight values that are too blue.
+COLOR = 1.0, 0.95, 0.75, 8
+
 [CustomEmissiveMulti]
 ; Wing light bar "glow" for BOTH taillights and brake lights.
 ; Compare to this recap of the 2016 Le Mans race:
@@ -60,16 +80,17 @@ Resolution = 2048, 2048
 ; Illuminate only the top section for the tail lights.
 ;@ = MultiItem, Role = ParkingLights, Center = "61, 318", Size = "46, 600", CornerRadius = 0, Exponent = 0.1, Color = "1, 0, 0", Intensity = 128, Location = "REAR"
 ; Illuminate only the bottom section for the tail lights.
-@ = MultiItem, Role = ParkingLights, Center = "139, 318", Size = "46, 600", CornerRadius = 0, Exponent = 0.1, Color = "1, 0, 0", Intensity = 128, Location = "REAR", Lag = 0, HeatingMult = 0
+@ = MultiItem, Role = ParkingLights, Center = "139, 318", Size = "46, 600", CornerRadius = 0, Exponent = 0.1, Color = "1, 0, 0", Intensity = 256, Location = "REAR", Lag = 0.0, HeatingMult = 0.0
 ; Illuminate both top and bottom sections for brake lights.
-@ = MultiItem, Role = BrakingLights, Center = "102, 318", Size = "132, 600", CornerRadius = 0, Exponent = 0.1, Color = "2, 0.01, 0.01", Intensity = 256, Location = "REAR", Lag = 0, HeatingMult = 0
+@ = MultiItem, Role = BrakingLights, Center = "102, 318", Size = "132, 600", CornerRadius = 0, Exponent = 0.1, Color = "2, 0.01, 0.01", Intensity = 768, Location = "REAR", Lag = 0.0, HeatingMult = 0.0
 
 [LIGHT_EXTRA_...]
 ; Explicit definition of beams for wing light bars.
 ; Similar to the auto-guess but with some tweaks.
+; Doesn't work with the emissive also set to Brake_Lights.
 AFFECTS_TRACK=1
 BIND_TO_BRAKELIGHTS=1
-COLOR=1,0,0,3
+COLOR=1,0,0,2
 DIFFUSE_CONCENTRATION=0.88
 DIRECTION=0,-0.5,-1
 EXTERIOR_ONLY=1
@@ -85,7 +106,7 @@ OFF_MULT=0
 POSITION=0, 0.932092, -2.3
 RANGE=10
 RANGE_GRADIENT_OFFSET=0.25
-SPOT=75
+SPOT=60
 SPOT_EDGE=0.34,0.34,0.34
 SPOT_EDGE_SHARPNESS=10
 SPOT_SHARPNESS=0.375
@@ -95,15 +116,15 @@ SPOT_SHARPNESS=0.375
 ; Unfortunately this also lights up the P3 indicator.
 Meshes = rpx2_body_misc_a_SUB2
 Resolution = 1024, 1024
-@ = MultiItem, Role = ParkingLights, Center = "46, 311", Size = 80, CornerRadius = 1, Exponent = 0.1, Color = "1, 0, 0", Intensity = 20, Location = "REAR"
-@ = MultiItem, Role = BrakingLights, Center = "46, 311", Size = 80, CornerRadius = 1, Exponent = 0.1, Color = "1, 0, 0", Intensity = 75, Location = "REAR"
+@ = MultiItem, Role = ParkingLights, Center = "46, 311", Size = 80, CornerRadius = 1, Exponent = 0.1, Color = "1, 0, 0", Intensity = 32, Location = "REAR"
+@ = MultiItem, Role = BrakingLights, Center = "46, 311", Size = 80, CornerRadius = 1, Exponent = 0.1, Color = "1, 0, 0", Intensity = 256, Location = "REAR"
 
 [LIGHT_EXTRA_...]
 ; Legality panel beams for brake lights.
 ; Positioned to appear as if they come from the light textures.
 AFFECTS_TRACK=1
 BIND_TO_BRAKELIGHTS=1
-COLOR=1,0,0,5
+COLOR=1,0,0,4
 DIFFUSE_CONCENTRATION=0.88
 DIRECTION=0,0,-1
 EXTERIOR_ONLY=1
@@ -129,7 +150,7 @@ SPOT_SHARPNESS=0.250
 ; with lower light intensity.
 AFFECTS_TRACK=1
 BIND_TO_HEADLIGHTS=1
-COLOR=1,0,0,2.5
+COLOR=1,0,0,2
 DIFFUSE_CONCENTRATION=0.88
 DIRECTION=0,0,-1
 EXTERIOR_ONLY=1

--- a/config/cars/mods/urd/urd_px2_loire.ini
+++ b/config/cars/mods/urd/urd_px2_loire.ini
@@ -6,24 +6,15 @@
 ; - brake lights are now explicitly defined
 ; - "legality panel" brake lights now light up (sort of)
 ; - "legality panel" lights now illuminate with headlights
-;
-; The "glow" effects for the rear diffuser ("legality panel")
-; are achieved in a hacky way by shining actual light effects
-; forward toward the appropriate spots on the car. We can't
-; simply use an EMISSIVE like we should, because URD didn't
-; define those LED-like elements as their own object in the
-; car model. If you assign an emissive to one of the parts near
-; the lights, you either light up the windows, or the chassis.
-; So we get to use this hack instead.
-; The "right" fix would be to include a .kn5 patch that defines
-; some LED-like objects in the model, and then change this file
-; to light those up appropriately.
+
+; brake/tail lights must be defined as CustomEmissives
+[INCLUDE: common/custom_emissive.ini]
 
 [EMISSIVE_LIGHT_...]
 ; changes instrument panel glow to link with headlights
 NAME=rpx1_sw_ads
 BIND_TO_HEADLIGHTS=1
-COLOR=0.6,0.6,1,1.5
+COLOR=0.6,0.6,1,1.0
 EXTERIOR_ONLY=0
 INTERIOR_ONLY=1
 LAG=0
@@ -33,9 +24,9 @@ OFF_COLOR=1,1,1,0.6
 ; steering wheel labels glow with headlights
 NAME=rpx1_sw_badges
 BIND_TO_HEADLIGHTS=1
-COLOR=0.8,1,0.2,0.5
+COLOR=0.8,1,0.2,0.25
 LAG=0
-OFF_COLOR=0
+OFF_MULT=0
 EXTERIOR_ONLY=0
 INTERIOR_ONLY=1
 
@@ -43,18 +34,17 @@ INTERIOR_ONLY=1
 ; dashboard labels glow with headlights
 NAME=rpx1_cockpit_badges
 BIND_TO_HEADLIGHTS=1
-COLOR=0.8,1,0.2,0.5
+COLOR=0.8,1,0.2,0.25
 LAG=0
 OFF_MULT=0
 EXTERIOR_ONLY=0
 INTERIOR_ONLY=1
 
 [LIGHT_BRAKE_...]
-; top brake lights
-; similar to the auto-guess but with some tweaks
-NAME=Brake_Lights
+; Explicit definition for top brake lights (on wing)
+; Similar to the auto-guess but with some tweaks.
 AFFECTS_TRACK=1
-COLOR=1,0,0,2
+COLOR=1,0,0,3
 DIFFUSE_CONCENTRATION=0.88
 DIRECTION=0,0,-1
 EXTERIOR_ONLY=1
@@ -63,8 +53,11 @@ FADE_SMOOTH=30
 INTERIOR_ONLY=0
 LAG=0
 LOCATION=REAR
+MIRROR=0.824944
+MIRROR_DIRECTION=0
 NO_SELF_SPECULAR=1
 OFF_MULT=0
+POSITION=0, 0.932092, -2.3
 RANGE=10
 RANGE_GRADIENT_OFFSET=0.25
 SPOT=160
@@ -73,70 +66,22 @@ SPOT_EDGE_SHARPNESS=10
 SPOT_SHARPNESS=0.375
 
 [LIGHT_BRAKE_...]
-; legality panel brake light beam
+; Legality panel beams for brake lights.
+; Positioned to appear as if they come from the light textures.
 AFFECTS_TRACK=1
-COLOR=1,0,0,2
+COLOR=1,0,0,5
 DIFFUSE_CONCENTRATION=0.88
 DIRECTION=0,0,-1
 EXTERIOR_ONLY=1
-FADE_AT=80
+FADE_AT=120
 FADE_SMOOTH=20
-INTERIOR_ONLY=0
-LAG=0
-LOCATION=REAR
-MIRROR=0.615
-NO_SELF_SPECULAR=1
-OFF_MULT=0
-POSITION=0, 0.13, -2.13
-RANGE=5
-RANGE_GRADIENT_OFFSET=0.25
-SPOT=45
-SPOT_EDGE=0.34,0.34,0.34
-SPOT_EDGE_SHARPNESS=10
-SPOT_SHARPNESS=0.250
-
-[LIGHT_BRAKE_...]
-; legality panel brake light glow
-; This is a bit of a hack. See comments at top of file.
-AFFECTS_TRACK=1
-COLOR=1,0,0,10
-DIFFUSE_CONCENTRATION=0.25
-DIRECTION=0,0,1
-EXTERIOR_ONLY=1
-FADE_AT=80
-FADE_SMOOTH=0.9
 INTERIOR_ONLY=0
 LAG=0
 LOCATION=REAR
 MIRROR=0.606
 NO_SELF_SPECULAR=1
 OFF_MULT=0
-POSITION=0, 0.145, -2.39
-RANGE=0.8
-RANGE_GRADIENT_OFFSET=0.01
-SPOT=45
-SPOT_EDGE=1,1,1
-SPOT_EDGE_SHARPNESS=0.75
-SPOT_SHARPNESS=1
-
-[LIGHT_EXTRA_...]
-; legality panel tail light beams with headlights
-; This is essentially a copy of the brake light beams above.
-AFFECTS_TRACK=1
-BIND_TO_HEADLIGHTS=1
-COLOR=1,0,0,1
-DIFFUSE_CONCENTRATION=0.88
-DIRECTION=0,0,-1
-EXTERIOR_ONLY=1
-FADE_AT=80
-FADE_SMOOTH=20
-INTERIOR_ONLY=0
-LAG=0
-LOCATION=REAR
-MIRROR=0.615
-NO_SELF_SPECULAR=1
-OFF_MULT=0
-POSITION=0, 0.13, -2.13
+POSITION=0, 0.14, -2.30
 RANGE=5
 RANGE_GRADIENT_OFFSET=0.25
 SPOT=45
@@ -145,27 +90,35 @@ SPOT_EDGE_SHARPNESS=10
 SPOT_SHARPNESS=0.250
 
 [LIGHT_EXTRA_...]
-; legality panel tail light glow with headlights
-; This is a bit of a hack. See comments at top of file.
-; This is essentially a copy of the brake light glow above.
+; Legality panel beams for taillights (bound to headlights).
+; This is essentially a copy of the brake light beams above,
+; with lower light intensity.
 AFFECTS_TRACK=1
 BIND_TO_HEADLIGHTS=1
-COLOR=1,0,0,6 
-DIFFUSE_CONCENTRATION=0.25
-DIRECTION=0,0,1
+COLOR=1,0,0,2.5
+DIFFUSE_CONCENTRATION=0.88
+DIRECTION=0,0,-1
 EXTERIOR_ONLY=1
-FADE_AT=80
-FADE_SMOOTH=0.9
+FADE_AT=120
+FADE_SMOOTH=20
 INTERIOR_ONLY=0
 LAG=0
 LOCATION=REAR
 MIRROR=0.606
 NO_SELF_SPECULAR=1
 OFF_MULT=0
-POSITION=0, 0.145, -2.39
-RANGE=0.8
-RANGE_GRADIENT_OFFSET=0.01
+POSITION=0, 0.14, -2.30
+RANGE=5
+RANGE_GRADIENT_OFFSET=0.25
 SPOT=45
-SPOT_EDGE=1,1,1
-SPOT_EDGE_SHARPNESS=0.75
-SPOT_SHARPNESS=1
+SPOT_EDGE=0.34,0.34,0.34
+SPOT_EDGE_SHARPNESS=10
+SPOT_SHARPNESS=0.250
+
+[CustomEmissiveMulti]
+; Legality panel "glow" for BOTH taillights and brake lights.
+; Unfortunately this also lights up the P3 indicator.
+Meshes = rpx2_body_misc_a_SUB2
+Resolution = 1024, 1024
+@ = MultiItem, Role = ParkingLights, Center = "46, 311", Size = 80, CornerRadius = 1, Exponent = 0.1, Color = "1, 0, 0", Intensity = 5, Location = "REAR"
+@ = MultiItem, Role = BrakingLights, Center = "46, 311", Size = 80, CornerRadius = 1, Exponent = 0.1, Color = "1, 0, 0", Intensity = 7, Location = "REAR"

--- a/config/cars/mods/urd/urd_px2_loire.ini
+++ b/config/cars/mods/urd/urd_px2_loire.ini
@@ -7,10 +7,10 @@
 ; - "legality panel" brake lights now light up (sort of)
 ; - "legality panel" lights now illuminate with headlights
 ;
-; The "glow" effects for the rear diffuser "legality panel"
+; The "glow" effects for the rear diffuser ("legality panel")
 ; are achieved in a hacky way by shining actual light effects
 ; forward toward the appropriate spots on the car. We can't
-; simply use an EMISSIVE like we should, because URD didn'tail
+; simply use an EMISSIVE like we should, because URD didn't
 ; define those LED-like elements as their own object in the
 ; car model. If you assign an emissive to one of the parts near
 ; the lights, you either light up the windows, or the chassis.


### PR DESCRIPTION
This pull request adds a custom configuration for the **PX2 Loire** (LMP2 Oreca O5) by United Racing Design.

The config provides two main features beyond what is auto-guessed:

| Goal | Achieved by... |
| --- | --- |
| Provide visual cue to the driver when headlights are on. | <ul><li>The instrument panel lights up with the headlights.</li><li>The dashboard labels light up with the headlights.</li></ul> |
| Make the tail lights and brake lights work. | <ul><li>brake lights are now explicitly defined</li><li>The "legality panel" brake lights now light up (sort of).</li><li>The "legality panel" lights now glow with the headlights.</li></ul> |

As noted in the file's comments, the "glow" effects for the rear diffuser ("legality panels" or "cheese wedges") are now achieved with `CustomEmissive` directives. This is great… except that the same sector of the `Chassis` texture that is used for these lights is also used for one of the position indicator lights, which also doesn't work quite right. Sigh. Well, at least it's less hacky this way.

The "right" fix would be to include a `.kn5` patch that defines some LED-like objects in the model, and then change this file to light those up appropriately. But I have neither the tools nor the knowledge to do it that way.

I've provided **[a demonstration video](https://streamable.com/4eutuz)** for this change, showing the new capabilities provided by the explicit configuration.