### PR TITLE
Added lighting config for Joesville.

### DIFF
--- a/config/tracks/joesville.ini
+++ b/config/tracks/joesville.ini
@@ -1,0 +1,101 @@
+; Lighting configuration for Joesville Raceway
+
+[ABOUT]
+AUTHOR = zerobandwidth
+VERSION = 0.1.20200719.01
+DATE_RELEASE = 2020.07.19
+LIGHTS_COUNT = 43
+NOTES = Perfect for some Thursday night lights.
+
+[INCLUDE: common/conditions.ini]
+[INCLUDE: common/custom_emissive.ini]
+
+[BASIC]
+SUPPORTS_WIND = 1
+RALLY_TRACK = 0
+
+[LIGHTING]
+BOUNCED_LIGHT_MULT = 1, 1, 1, 1
+CAR_LIGHTS_LIT_MULT = 1
+ENABLE_TREES_LIGHTING = 1
+LIT_MULT = 1
+SPECULAR_MULT = 1
+
+[GRASS_FX]
+GRASS_MATERIALS = GRASS_TERRAIN
+OCCLUDING_MATERIALS = RDCP_PITLANE_WET, ROAD_TRACKMAIN_WET
+SHAPE_SIZE = 2.5
+
+; ---- CONDITIONS -------------------------------------------------------------
+
+[CONDITION_...]
+; Indicates "caution" for FCY, slippery track, slow car
+NAME = RACE_FLAG_CAUTION
+INPUT = FLAG_TYPE
+LUT = (|0=0|1=0|2=1|3=1|4=0|5=0|6=1|7=0|14=0|)
+
+; ---- LIGHT POLES ------------------------------------------------------------
+
+[CustomEmissive]
+; Limits light pole glow to just the lamp texture.
+Materials = LARGEPROPS
+Resolution = 1024, 1024
+@ = CustomEmissive_Rect, Start = "412, 179", Size = "103, 106", CornerRadius = 0.1, Exponent = 0.1
+
+[MATERIAL_ADJUSTMENT_...]
+DESCRIPTION = light pole emissives
+MATERIALS = LARGEPROPS
+CONDITION = NIGHT_SMOOTH
+KEY_0 = ksEmissive
+VALUE_0 = 1, 1, 0.8, 128
+VALUE_0_OFF = 0
+
+[LIGHT_SERIES_...]
+DESCRIPTION = light pole beams
+MESHES = LightPosts
+ACTIVE = 1
+CONDITION = NIGHT_SMOOTH
+COLOR = 1, 0.9, 0.7, 2.5
+DIFFUSE_CONCENTRATION = 0.8
+DIRECTION = NORMAL
+DIRECTION_ALTER = -0.90, -0.75, -2.90
+FADE_AT = 500
+FADE_SMOOTH = 100
+OFFSET = 0.00, 1.30, 0.00
+RANGE = 100
+RANGE_GRADIENT_OFFSET = 0.9
+SPECULAR_MULT = 0.8
+SPOT = 120
+SPOT_SHARPNESS = 0.1
+SPOT_EDGE = 0.5
+SPOT_EDGE_SHARPNESS = 10
+
+; ---- SIGNAL LIGHTS ----------------------------------------------------------
+
+[MATERIAL_ADJUSTMENT_...]
+DESCRIPTION = red lights under caution
+MATERIALS = RDLTA, RDLTB
+CONDITION = RACE_FLAG_CAUTION
+KEY_0 = ksEmissive
+VALUE_0 = 1, 0.4, 0.2, 64
+VALUE_0_OFF = 0
+
+; ---- PRESS BOX --------------------------------------------------------------
+
+[MATERIAL_ADJUSTMENT_...]
+DESCRIPTION = window glow in press box
+MATERIALS = TSO_GLASS
+CONDITION = NIGHT_SHARP
+KEY_0 = ksEmissive
+VALUE_0 = 0.96, 0.80, 0.50, 10
+VALUE_0_OFF = 0
+
+; ---- SIGNS ------------------------------------------------------------------
+
+[MATERIAL_ADJUSTMENT_...]
+DESCRIPTION = Synergy Energy sign glow
+MATERIALS = SPONSORSPHERE
+CONDITION = NIGHT_SMOOTH
+KEY_0 = ksEmissive
+VALUE_0 = 1, 1, 1, 1
+VALUE_0_OFF = 0


### PR DESCRIPTION
It's a tiny oval track. It already has light poles. There are hundreds of tracks just like this one across America.

This mod might not have a lot, but it had one thing.

A need for night racing.

* all track lighting activates "at night" and covers the entire oval
* red lights under flag stand flash if caution is out
* press box windows glow at night
* Synergy Energy signs glow at night
* also adds `GRASS_FX` spec

![Overhead view](https://imgur.com/5ik3Px4.png)
![Another overhead view](https://imgur.com/h8RB1Cb.png)
![Glowing signs](https://imgur.com/8vB2HfC.png)
![The view from the press box.](https://imgur.com/ZHTjb12.png)
![The view from the road](https://imgur.com/1MGbNgR.png)