### PR TITLE
Added lighting for Weatherfield (fictional track).

### DIFF
--- a/config/tracks/weatherfieldinternationalspeedway.ini
+++ b/config/tracks/weatherfieldinternationalspeedway.ini
@@ -1,0 +1,520 @@
+; Lighting configuration for Weatherfield Raceway
+
+[ABOUT]
+AUTHOR = zerobandwidth
+VERSION = 0.1.20200819.01
+DATE_RELEASE = 2020.08.19
+LIGHTS_COUNT = 495
+NOTES = For Weatherfield v0.8. Might be overcrowded, as there is some pop-in in the stadium section.
+
+[INCLUDE: common/conditions.ini]
+[INCLUDE: common/custom_emissive.ini]
+[INCLUDE: common/materials_track.ini]
+
+[BASIC]
+SUPPORTS_WIND = 1
+RALLY_TRACK = 0
+
+[LIGHTING]
+BOUNCED_LIGHT_MULT = 1, 1, 1, 1
+CAR_LIGHTS_LIT_MULT = 1
+ENABLE_TREES_LIGHTING = 1
+LIT_MULT = 1
+SPECULAR_MULT = 1
+
+[GRASS_FX]
+GRASS_MESHES = 1GRASS_0
+OCCLUDING_MATERIALS = Concrete_Aggregate_Smoke, Concrete_Aggregate_Smoke2, Concrete_Aggregate_Smoke3, Concrete_Aggregate_Smoke4, Rumble1, Rumble2, "Tarmac Dark AC", TarmacLightAC, TarmacOldAC
+; Do we want trackside sand to occlude grass? If so:
+OCCLUDING_MESHES = 1GRASS_4, 1GRASS_6, 1GRASS_20, 1GRASS_22, 1GRASS_24, 1GRASS_26, 1GRASS_28, 1GRASS_30, 1GRASS_33, 1GRASS_35, 1GRASS_39, 1GRASS_42, 1GRASS_44
+SHAPE_SIZE = 2.5
+
+[CONDITION...]
+NAME = ALWAYS_FLASHY
+INPUT = ONE
+FLASHING_FREQUENCY = 10
+FLASHING_SMOOTHNESS = 0.3
+FLASHING_SKIP_OFF_STATE = 0
+FLASHING_MIN_VALUE = 0.0
+FLASHING_NOISE_AMPLITUDE = 0
+FLASHING_SYNCED = 0
+
+[CONDITION_...]
+; Indicates "green" for actual green or when not racing.
+NAME = RACE_FLAG_GREEN
+INPUT = FLAG_TYPE
+LUT = (|0=1|1=1|2=0|14=0|)
+
+[CONDITION_...]
+; Indicates "caution" for FCY, slippery track, slow car
+NAME = RACE_FLAG_CAUTION
+INPUT = FLAG_TYPE
+LUT = (|0=0|1=0|2=1|3=1|4=0|5=0|6=1|7=0|14=0|)
+
+[CONDITION_...]
+NAME = PIT_EXIT_RED_LIGHT
+INPUT = FLAG_TYPE
+LUT = (|0=0|3=0|4=1|5=0)
+
+[CONDITION_...]
+NAME = PIT_EXIT_GREEN_LIGHT
+INPUT = FLAG_TYPE
+LUT = (|0=1|4=0|6=1|8=0|12=1)
+
+[CONDITION_...]
+NAME = PIT_EXIT_BLUE_LIGHT
+INPUT = FLAG_TYPE
+LUT = (|0=0|12=1|13=0)
+
+; ---- LIGHT POLES --------------------------------------------
+
+[CustomEmissive]
+; Limits light pole glow to just the lamp texture.
+Materials = Lightpole1
+Resolution = 1024, 1024
+@ = CustomEmissive_Rect, Start = "555, 301", Size = "367, 634", CornerRadius = 0.1, Exponent = 0.1
+
+[MATERIAL_ADJUSTMENT_...]
+DESCRIPTION = light pole emissives
+MATERIALS = Lightpole1
+CONDITION = NIGHT_SMOOTH
+KEY_0 = ksEmissive
+VALUE_0 = 1, 1, 0.8, 256
+VALUE_0_OFF = 0
+
+[LIGHT_SERIES_...]
+DESCRIPTION = light pole lamps left
+MATERIALS = Lightpole1
+ACTIVE = 1
+CONDITION = NIGHT_SMOOTH
+COLOR = 1, 0.9, 0.7, 5
+DIFFUSE_CONCENTRATION = 0.8
+DIRECTION = NORMAL
+DIRECTION_OFFSET = 0.25, -1, 0.25
+FADE_AT = 500
+FADE_SMOOTH = 100
+OFFSET = -0.24, -1.2, 0.43
+RANGE = 75
+RANGE_GRADIENT_OFFSET = 0.9
+SPECULAR_MULT = 0.8
+SPOT = 108
+SPOT_SHARPNESS = 0.1
+SPOT_EDGE = 0.5
+SPOT_EDGE_SHARPNESS = 10
+
+[LIGHT_SERIES_...]
+DESCRIPTION = light pole lamps right
+MATERIALS = Lightpole1
+ACTIVE = 1
+CONDITION = NIGHT_SMOOTH
+COLOR = 1, 0.9, 0.7, 5
+DIFFUSE_CONCENTRATION = 0.8
+DIRECTION = NORMAL
+DIRECTION_OFFSET = 0.25, -1, -0.5
+FADE_AT = 500
+FADE_SMOOTH = 100
+OFFSET = -0.4, -1.2, -0.3
+RANGE = 75
+RANGE_GRADIENT_OFFSET = 0.9
+SPECULAR_MULT = 0.8
+SPOT = 108
+SPOT_SHARPNESS = 0.1
+SPOT_EDGE = 0.5
+SPOT_EDGE_SHARPNESS = 10
+
+; ---- PODIUM LIGHTING ----------------------------------------
+
+[LIGHT_SERIES_...]
+DESCRIPTION = imaginary light shining on podium
+MESHES = OBJ1919
+ACTIVE = 0
+CONDITION = NIGHT_SMOOTH
+COLOR = 1, 0.9, 0.7, 5
+DIFFUSE_CONCENTRATION = 0.8
+DIRECTION = NORMAL
+DIRECTION_OFFSET = 0.0, 0.0, 0.0
+FADE_AT = 500
+FADE_SMOOTH = 100
+OFFSET = 0.0, 0.0, 0.0
+RANGE = 20
+RANGE_GRADIENT_OFFSET = 0.9
+SPECULAR_MULT = 0.8
+SPOT = 108
+SPOT_SHARPNESS = 0.1
+SPOT_EDGE = 0.5
+SPOT_EDGE_SHARPNESS = 10
+
+; ---- SIGNAL LIGHTS ------------------------------------------
+
+[MATERIAL_ADJUSTMENT_...]
+DESCRIPTION = green lights on race control board
+MATERIALS = Material #32
+CONDITION = RACE_FLAG_GREEN
+KEY_0 = ksEmissive
+VALUE_0 = 0, 1, 0, 64
+VALUE_0_OFF = 0
+
+[MATERIAL_ADJUSTMENT_...]
+DESCRIPTION = yellow lights under caution
+MESHES = OBJ1911
+CONDITION = RACE_FLAG_CAUTION
+KEY_0 = ksEmissive
+VALUE_0 = 1, 0.9, 0, 64
+VALUE_0_OFF = 0
+
+[MATERIAL_ADJUSTMENT_...]
+DESCRIPTION = green light at end of pit lane
+MESHES = OBJ2262
+CONDITION = PIT_EXIT_GREEN_LIGHT
+KEY_0 = ksEmissive
+VALUE_0 = 0, 1, 0, 64
+VALUE_0_OFF = 0
+
+[MATERIAL_ADJUSTMENT_...]
+DESCRIPTION = red light at end of pit lane
+MESHES = OBJ2261
+CONDITION = PIT_EXIT_RED_LIGHT
+KEY_0 = ksEmissive
+VALUE_0 = 1, 0, 0, 64
+VALUE_0_OFF = 0
+
+[MATERIAL_ADJUSTMENT_...]
+DESCRIPTION = blue lights at end of pit lane
+MATERIALS = mat250
+CONDITION = PIT_EXIT_BLUE_LIGHT
+KEY_0 = ksEmissive
+VALUE_0 = 0, 0, 1, 64
+VALUE_0_OFF = 0
+
+; ---- BUILDINGS ----------------------------------------------
+
+[Material_RoomWindows]
+; big MOTUL building
+Materials = box1-1
+DebugMode = 0
+EmissiveMode = ONE
+RoomHeight = 12.00
+RoomVerticalOffset = -7.25
+RoomCeilingRotation = 15
+RoomCeilingScale = 0.5
+EmissiveDiffuseMult = 1
+EmissiveDiffuseEXP = -1
+
+[MATERIAL_ADJUSTMENT_...]
+DESCRIPTION = generic non-frosty glass glow
+MATERIALS = box1-1
+CONDITION = NIGHT_SHARP
+KEY_0 = ksEmissive
+VALUE_0 = 0.96, 0.80, 0.50, 1
+VALUE_0_OFF = 0
+
+[MATERIAL_ADJUSTMENT_...]
+DESCRIPTION = generic frosty glass glow
+MATERIALS = box1-9
+CONDITION = NIGHT_SHARP
+KEY_0 = ksEmissive
+VALUE_0 = 0.96, 0.80, 0.50, 1
+VALUE_0_OFF = 0
+
+[CustomEmissive]
+Materials = mat57
+Resolution = 512, 256
+@ = CustomEmissive_Rect, Channel = 0, Start = "6, 55", Size = "116, 202", CornerRadius = 0.0, Exponent = 0.45
+@ = CustomEmissive_Rect, Channel = 1, Start = "132, 55", Size = "116, 202"
+@ = CustomEmissive_Rect, Channel = 2, Start = "261, 55", Size = "116, 202"
+@ = CustomEmissive_Rect, Channel = 3, Start = "389, 55", Size = "116, 202"
+
+[MATERIAL_ADJUSTMENT_...]
+DESCRIPTION = building window glow (mat57)
+MATERIALS = mat57
+CONDITION = NIGHT_SHARP
+KEY_0 = ksEmissive
+VALUE_0 = 0.96, 0.80, 0.50, 4
+VALUE_0_OFF = 0
+KEY_1 = ksEmissive1
+VALUE_1 = 0.96, 0.80, 0.50, 4
+VALUE_1_OFF = 0
+KEY_2 = ksEmissive2
+VALUE_2 = 0.96, 0.80, 0.50, 4
+VALUE_2_OFF = 0
+KEY_3 = ksEmissive3
+VALUE_3 = 0.96, 0.80, 0.50, 4
+VALUE_3_OFF = 0
+
+[Material_RoomWindows]
+Materials = mat82
+DebugMode = 0
+EmissiveMode = DIFFUSE_EMISSIVE_BLEND
+RoomHeight = 3.1
+RoomCeilingRotation = 15
+RoomCeilingScale = 0.5
+EmissiveDiffuseMult = 5
+EmissiveDiffuseEXP = -2
+
+[MATERIAL_ADJUSTMENT_...]
+DESCRIPTION = building window glow (mat82)
+CONDITION = NIGHT_SHARP
+MATERIALS = mat82
+KEY_0 = ksEmissive
+VALUE_0 = 0.96, 0.80, 0.50, 8
+VALUE_0_OFF = 0
+
+[Material_RoomWindows]
+Materials = mat87
+DebugMode = 0
+EmissiveMode = DIFFUSE_EMISSIVE_BLEND
+RoomHeight = 3.6
+RoomCeilingRotation = 15
+RoomCeilingScale = 0.5
+EmissiveDiffuseMult = 1.0
+EmissiveDiffuseEXP = -0.4
+
+[MATERIAL_ADJUSTMENT_...]
+DESCRIPTION = building window glow (mat87)
+CONDITION = NIGHT_SHARP
+MATERIALS = mat87
+KEY_0 = ksEmissive
+VALUE_0 = 0.96, 0.80, 0.50, 1
+VALUE_0_OFF = 0
+
+[CustomEmissive]
+Materials = mat88
+Resolution = 256, 256
+@ = CustomEmissive_Rect, Channel = 0, Start = "87, 94", Size = "32, 39", CornerRadius = 0.0, Exponent = 0.45
+@ = CustomEmissive_Rect, Channel = 1, Start = "130, 94", Size = "32, 39", CornerRadius = 0.0, Exponent = 0.45
+@ = CustomEmissive_Rect, Channel = 2, Start = "87, 138", Size = "32, 42"
+@ = CustomEmissive_Rect, Channel = 3, Start = "130, 138", Size = "32, 42"
+
+[MATERIAL_ADJUSTMENT_...]
+DESCRIPTION = building window glow (mat88)
+MATERIALS = mat88
+CONDITION = NIGHT_SHARP
+KEY_0 = ksEmissive
+VALUE_0 = 0.96, 0.80, 0.50, 4
+VALUE_0_OFF = 0
+KEY_1 = ksEmissive1
+VALUE_1 = 0.96, 0.80, 0.50, 4
+VALUE_1_OFF = 0
+KEY_2 = ksEmissive2
+VALUE_2 = 0.96, 0.80, 0.50, 4
+VALUE_2_OFF = 0
+KEY_3 = ksEmissive3
+VALUE_3 = 0.96, 0.80, 0.50, 4
+VALUE_3_OFF = 0
+
+[Material_RoomWindows]
+Materials = mat91, mat92
+DebugMode = 0
+EmissiveMode = DIFFUSE_TEXTURE
+;EmissiveMode = DIFFUSE_WITH_EMISSIVE
+;EmissiveMode = DIFFUSE_EMISSIVE_BLEND
+;EmissiveMode = ONE
+RoomHeight = 3.98
+RoomCeilingRotation = 15
+RoomCeilingScale = 0.5
+EmissiveDiffuseMult = 5.0
+EmissiveDiffuseEXP = -2.0
+
+[MATERIAL_ADJUSTMENT_...]
+DESCRIPTION = building window glow (mat91 and mat92)
+MATERIALS = mat91, mat92
+CONDITION = NIGHT_SHARP
+KEY_0 = ksEmissive
+VALUE_0 = 1.00, 0.90, 0.50, 6
+VALUE_0_OFF = 0
+
+[SHADER_REPLACEMENT_...]
+DESCRIPTION = building window glow (mat228)
+MATERIALS = mat228, mat91, mat92, mat82
+; mat91 was windows02.dds
+; mat92 was windside.dds
+; mat82 was wallcb04.dds
+SHADER = ksPerPixelMultiMap_emissive
+RESOURCE_0 = txDiffuse
+RESOURCE_1 = txNormal
+RESOURCE_2 = txMaps
+RESOURCE_3 = txDetail
+RESOURCE_4 = txEmissive
+RESOURCE_TEXTURE_0 = suite_windows.dds
+RESOURCE_TEXTURE_1 = suite_windows.dds
+RESOURCE_TEXTURE_2 = suite_windows.dds
+RESOURCE_TEXTURE_3 = suite_windows.dds
+RESOURCE_TEXTURE_4 = suite_windows.dds
+
+[Material_RoomWindows]
+Materials = mat228
+DebugMode = 0
+EmissiveMode = DIFFUSE_TEXTURE
+RoomHeight = 3.9
+RoomCeilingRotation = 15
+RoomCeilingScale = 0.5
+EmissiveDiffuseMult = 5.0
+EmissiveDiffuseEXP = -2.0
+
+[MATERIAL_ADJUSTMENT_...]
+DESCRIPTION = building window glow (mat228)
+MATERIALS = mat228
+CONDITION = NIGHT_SHARP
+KEY_0 = ksEmissive
+VALUE_0 = 0.96, 0.80, 0.50, 4
+VALUE_0_OFF = 0
+
+[LIGHT_SERIES_...]
+DESCRIPTION = grandstand canopies
+MATERIALS = mat184, mat170, mat207, mat220
+ACTIVE = 1
+CONDITION = NIGHT_SMOOTH
+COLOR = 1, 0.9, 0.7, 3
+DIFFUSE_CONCENTRATION = 0.8
+DIRECTION = 0.0, -1.0, 0.0
+FADE_AT = 500
+FADE_SMOOTH = 100
+OFFSET = 0.0, 0.0, 0.0
+RANGE = 50
+RANGE_GRADIENT_OFFSET = 0.9
+SPECULAR_MULT = 0.8
+SPOT = 120
+SPOT_SHARPNESS = 0.1
+SPOT_EDGE = 0.5
+SPOT_EDGE_SHARPNESS = 10
+
+; ---- PIT STALLS ---------------------------------------------
+
+[CustomEmissive]
+; Limits light pole glow to just the lamp texture.
+Materials = mat237
+Resolution = 512, 512
+; Start = "94.4, 161.4", Size = "64.7, 45.6"
+@ = CustomEmissive_Rect, Channel = 0, Start = "94.4, 161.4", Size = "64.7, 45.6", CornerRadius = 0.3, Exponent = 0.1
+@ = CustomEmissive_Rect, Channel = 1, Start = "392.4, 60.7", Size = "44.2, 34.3", CornerRadius = 0.3, Exponent = 0.1
+
+[MATERIAL_ADJUSTMENT_...]
+DESCRIPTION = pit engineer stand emissives
+MATERIALS = mat237
+CONDITION = NIGHT_SHARP
+KEY_0 = ksEmissive
+VALUE_0 = 1, 1, 0.8, 64
+VALUE_0_OFF = 0
+KEY_1 = ksEmissive1
+VALUE_1 = 0.8, 1.0, 0.9, 2
+VALUE_1_OFF = 0.8, 1.0, 0.9, 1
+
+; ---- AMBULANCES AND OTHER RESCUE VEHICLES -------------------
+
+[CustomEmissive]
+; actual ambulance lights
+Materials = amb1
+Resolution = 512, 128
+@ = CustomEmissive_Rect, Channel = 0, Start = "116, 7", Size = "35, 7"
+@ = CustomEmissive_Rect, Channel = 1, Start = "170, 7", Size = "35, 7"
+@ = CustomEmissive_Rect, Channel = 2, Start = "227, 7", Size = "35, 7"
+
+[MATERIAL_ADJUSTMENT_...]
+DESCRIPTION = actual ambulance lights
+MATERIALS = amb1
+ACTIVE = 1
+CONDITION = RACE_FLAG_CAUTION
+;CONDITION = ALWAYS_ON
+KEY_0 = ksEmissive
+VALUE_0 = 0, 0.1, 1, 128
+VALUE_0_OFF = 0
+KEY_1 = ksEmissive1
+VALUE_1 = 0, 0.1, 1, 128
+VALUE_1_OFF = 0
+KEY_2 = ksEmissive2
+VALUE_2 = 0, 0.1, 1, 128
+VALUE_2_OFF = 0
+
+[CustomEmissive]
+; red fire car lights
+Materials = obj_car1
+Resolution = 256, 64
+@ = CustomEmissive_Rect, Channel = 0, Start = "79, 6", Size = "7, 8"
+;@ = CustomEmissive_Circle, Channel = 1, Center = "67, 10", Size = "3"
+
+[MATERIAL_ADJUSTMENT_...]
+DESCRIPTION = red fire car lights
+MATERIALS = obj_car1
+CONDITION = RACE_FLAG_CAUTION
+;CONDITION = ALWAYS_ON
+KEY_0 = ksEmissive
+VALUE_0 = 0, 0.1, 1, 128
+VALUE_0_OFF = 0
+;KEY_1 = ksEmissive1
+;VALUE_1 = 1, 1, 1, 256
+;VALUE_1_OFF = 0
+
+[CustomEmissive]
+; blue rescue truck lights
+Materials = MOSPORT_RESCUE
+Resolution = 512, 512
+@ = CustomEmissive_Rect, Channel = 0, Start = "345, 43", Size = "166, 70"
+@ = CustomEmissive_Poly, Channel = 1, P1 = "24, 209", P2 = "46, 210", P3 = "57, 231", P4 = "23, 229"
+@ = CustomEmissive_Poly, Channel = 2, P1 = "173, 210", P2 = "198, 209", P3 = "199, 229", P4 = "162, 231"
+
+[MATERIAL_ADJUSTMENT_...]
+DESCRIPTION = blue rescue truck lights
+MATERIALS = MOSPORT_RESCUE
+ACTIVE = 1
+CONDITION = RACE_FLAG_CAUTION
+;CONDITION = ALWAYS_ON
+KEY_0 = ksEmissive
+VALUE_0 = 0, 0.1, 1, 128
+VALUE_0_OFF = 0
+KEY_1 = ksEmissive1
+VALUE_1 = 1, 1, 1, 256
+VALUE_1_OFF = 0
+KEY_2 = ksEmissive2
+VALUE_2 = 1, 1, 1, 256
+VALUE_2_OFF = 0
+
+; ---- MARSHAL STANDS -----------------------------------------
+
+[LIGHT_SERIES_...]
+DESCRIPTION = single-person marshal stands - ceiling lights
+MESHES = OBJ110_SUB4, OBJ137_SUB4, OBJ154_SUB4, OBJ155_SUB4, OBJ156_SUB4, OBJ157_SUB4, OBJ163_SUB4
+ACTIVE = 1
+CONDITION = NIGHT_SHARP
+COLOR = 1, 0.9, 0.7, 5
+DIFFUSE_CONCENTRATION = 0.8
+DIRECTION = 0.0, -1.0, 0.0
+FADE_AT = 500
+FADE_SMOOTH = 100
+OFFSET = 0.0, 2.2, 0.0
+RANGE = 4
+RANGE_GRADIENT_OFFSET = 0.9
+SPECULAR_MULT = 0.8
+SPOT = 75
+SPOT_SHARPNESS = 0.1
+SPOT_EDGE = 0.5
+SPOT_EDGE_SHARPNESS = 10
+
+[LIGHT_SERIES_...]
+DESCRIPTION = two-person marshal stands - ceiling lights
+MESHES = OBJ78_SUB1, OBJ131_SUB1
+ACTIVE = 1
+CONDITION = NIGHT_SHARP
+COLOR = 1, 0.9, 0.7, 5
+DIFFUSE_CONCENTRATION = 0.8
+DIRECTION = 0.0, -1.0, 0.0
+FADE_AT = 500
+FADE_SMOOTH = 100
+OFFSET = 0.0, 0.8, 0.0
+RANGE = 4
+RANGE_GRADIENT_OFFSET = 0.9
+SPECULAR_MULT = 0.8
+SPOT = 90
+SPOT_SHARPNESS = 0.1
+SPOT_EDGE = 0.5
+SPOT_EDGE_SHARPNESS = 10
+
+; ---- OTHER LIGHTS -------------------------------------------
+
+[MATERIAL_ADJUSTMENT_...]
+DESCRIPTION = recording lights on TV cameras
+MATERIALS = mat40, mat110
+CONDITION = ALWAYS_ON
+KEY_0 = ksEmissive
+VALUE_0 = 1, 0, 0, 0.750
+VALUE_0_OFF = 0
+


### PR DESCRIPTION
This is a first try at a lighting configuration for [Weatherfield Raceway](https://www.racedepartment.com/downloads/fictional-racetrack-weatherfield-international-raceway.21641/), a fictional track on RaceDepartment which has been lurking out there and is now getting attention from the author again. I had already started on this a while ago as a way to learn track lighting, and when the track was more recently updated, I got [the author's explicit encouragement](https://www.racedepartment.com/threads/fictional-racetrack-weatherfield-international-raceway.155476/post-3243029) to go ahead and submit the lighting config here, rather than making it part of the mod itself.

### Features ###

* all light poles lit at night
* some race control lights light up
* all marshal stands lit at night
* many buildings lit at night
* ambulances and other emergency vehicles should light up under caution

### Screenshots ###

![view of front straight lighting, including signal light board](https://imgur.com/tu8G3me.png)
![view of turn 1 lighting](https://imgur.com/xmeBjZm.png)
![view of stadium section from above turn 1](https://imgur.com/u9cyOtm.png)
![view of back straight lighting](https://imgur.com/eWRTyMT.png)

### Author's Comments ###

The configuration is functional enough for now. However, there are some places in the stadium section where the number of visible light sources can peak above 300, causing some "pop-in" of distant lights. Disabling all lighting on the grandstands would alleviate this, but will leave some sectors of the track totally dark. I don't know whether this will get better or worse in future updates, but it's at least usable.

This is a lesser-known fictional track but it's super fun and this will make it a bit more functional at night. Check it out, and enjoy. 😄 