### PR TITLE
Update ks_porsche_911_gt3_rs.ini

### DIFF
--- a/config/cars/kunos/ks_porsche_911_gt3_rs.ini
+++ b/config/cars/kunos/ks_porsche_911_gt3_rs.ini
@@ -159,7 +159,7 @@ CarPaintVersionAware = 3
 [Material_LicensePlate_Europe]
 
 [SHAKING_EXHAUST_...]
-MESHES = GEO_Body_SUB3, GEO_Body_SUB9
+MESHES = '{ lod:A & (GEO_Body_SUB3, GEO_Body_SUB9)}'
 POINT_0 = 0.0, 0.28, -2.23
 
 [REAL_MIRROR_1]


### PR DESCRIPTION
Fixing glass shader for lod B
Cause of same naming in lod A and lod B