### PR TITLE
Added replacement for circuit_sebring2021

### DIFF
--- a/config/tracks/circuit_sebring2021.ini
+++ b/config/tracks/circuit_sebring2021.ini
@@ -1,0 +1,265 @@
+; Replacement CSP configuration for MadBrain's Sebring 2021 DAY layout.
+; This should make the DAY layout function around the clock.
+
+[ABOUT]
+AUTHOR = zer0bandwidth
+VERSION = 1.0.1.20210926.01
+DATE_RELEASE = 2021-09-26
+NOTES = Replaces config that comes with mod. Makes DAY layout usable at any ToD.
+ 
+[INCLUDE: common/conditions.ini]
+[INCLUDE: common/custom_emissive.ini]
+[INCLUDE: common/materials_track.ini]
+
+[BASIC]
+RALLY_TRACK = 0
+
+[LIGHTING]
+BOUNCED_LIGHT_MULT = 1, 1, 1, 1
+CAR_LIGHTS_LIT_MULT = 1
+ENABLE_TREES_LIGHTING = 1
+LIT_MULT = 1
+SPECULAR_MULT = 1
+
+[GRASS_FX]
+GRASS_MESHES = 1OUT
+OCCLUDING_MATERIALS = Concrete_Aggregate_Smoke, Concrete_Aggregate_Smoke2, Concrete_Aggregate_Smoke3, Concrete_Aggregate_Smoke4, Rumble1, Rumble2, "Tarmac Dark AC", TarmacLightAC, TarmacOldAC
+OCCLUDING_MESHES = 
+SHAPE_SIZE = 1.0
+
+; ---- CUSTOM CONDITIONS ------------------------------------------------------
+
+[CONDITION_...]
+; Indicates "caution" for FCY, slippery track, slow car
+NAME = RACE_FLAG_CAUTION
+INPUT = FLAG_TYPE
+LUT = (|0=0|1=0|2=1|3=1|4=0|5=0|6=1|7=0|14=0|)
+
+; ---- LIGHT POLES ------------------------------------------------------------
+
+[MATERIAL_ADJUSTMENT_...]
+DESCRIPTION = single-light pole emissives
+MESHES = OBJ28_SUB1, OBJ29_SUB1, OBJ31_SUB1, OBJ32_SUB1, OBJ432_SUB1, OBJ433_SUB1, OBJ434_SUB1
+CONDITION = NIGHT_SMOOTH
+KEY_0 = ksEmissive
+VALUE_0 = 1, 1, 0.8, 256
+VALUE_0_OFF = 0
+
+[LIGHT_SERIES_...]
+DESCRIPTION = single-light pole illuminations, biased (front straight)
+MESHES = OBJ28_SUB1, OBJ434_SUB1
+ACTIVE = 1
+CONDITION = NIGHT_SMOOTH
+COLOR = 1, 0.9, 0.8, 8
+DIFFUSE_CONCENTRATION = 0.8
+DIRECTION = NORMAL
+DIRECTION_OFFSET = 0, -0.25, 1
+FADE_AT = 500
+FADE_SMOOTH = 100
+RANGE = 75
+RANGE_GRADIENT_OFFSET = 0.9
+SPECULAR_MULT = 0.8
+SPOT = 135
+SPOT_SHARPNESS = 0.1
+SPOT_EDGE = 0.5
+SPOT_EDGE_SHARPNESS = 10
+
+[LIGHT_SERIES_...]
+DESCRIPTION = single-light pole illuminations, unbiased (elsewhere)
+MESHES = OBJ29_SUB1, OBJ31_SUB1, OBJ32_SUB1, OBJ432_SUB1, OBJ433_SUB1
+ACTIVE = 1
+CONDITION = NIGHT_SMOOTH
+COLOR = 1, 0.9, 0.8, 8
+DIFFUSE_CONCENTRATION = 0.8
+DIRECTION = NORMAL
+FADE_AT = 500
+FADE_SMOOTH = 100
+RANGE = 75
+RANGE_GRADIENT_OFFSET = 0.9
+SPECULAR_MULT = 0.8
+SPOT = 135
+SPOT_SHARPNESS = 0.1
+SPOT_EDGE = 0.5
+SPOT_EDGE_SHARPNESS = 10
+
+[MATERIAL_ADJUSTMENT_...]
+DESCRIPTION = multi-light pole emissives
+MESHES = OBJ151_SUB1, OBJ152_SUB1, OBJ153_SUB1, OBJ154_SUB1, OBJ155_SUB1, OBJ492_SUB1, OBJ493_SUB1, OBJ494_SUB1, OBJ495_SUB1, OBJ496_SUB1, OBJ497_SUB1, OBJ498_SUB1, OBJ499_SUB1
+CONDITION = NIGHT_SMOOTH
+KEY_0 = ksEmissive
+VALUE_0 = 1, 1, 0.8, 256
+VALUE_0_OFF = 0
+
+[LIGHT_SERIES_...]
+DESCRIPTION = multi-light pole illuminations
+MESHES = OBJ151_SUB1, OBJ152_SUB1, OBJ153_SUB1, OBJ154_SUB1, OBJ155_SUB1, OBJ492_SUB1, OBJ493_SUB1, OBJ494_SUB1, OBJ495_SUB1, OBJ496_SUB1, OBJ497_SUB1, OBJ498_SUB1, OBJ499_SUB1
+ACTIVE = 1
+CONDITION = NIGHT_SMOOTH
+COLOR = 1, 0.9, 0.8, 8
+DIFFUSE_CONCENTRATION = 0.8
+DIRECTION = NORMAL
+DIRECTION_ALTER = 0, 0, 1
+FADE_AT = 500
+FADE_SMOOTH = 100
+RANGE = 100
+RANGE_GRADIENT_OFFSET = 0.8
+SPECULAR_MULT = 0.7
+SPOT = 165
+SPOT_SHARPNESS = 0.1
+SPOT_EDGE = 0.5
+SPOT_EDGE_SHARPNESS = 20
+
+[CustomEmissive]
+; Rectangular light pole light elements
+Materials = Lightpole1
+Resolution = 1024, 1024
+@ = CustomEmissive_Rect, Start = "555, 301", Size = "367, 634", CornerRadius = 0.1, Exponent = 0.1
+
+[MATERIAL_ADJUSTMENT_...]
+DESCRIPTION = short rectangular light pole emissives
+MATERIALS = Lightpole1
+CONDITION = NIGHT_SMOOTH
+KEY_0 = ksEmissive
+VALUE_0 = 1, 0.9, 0.7, 256
+VALUE_0_OFF = 0
+
+[LIGHT_SERIES_...]
+DESCRIPTION = short rectangular light pole illuminations
+MATERIALS = Lightpole1
+ACTIVE = 1
+CONDITION = NIGHT_SMOOTH
+COLOR = 1, 0.9, 0.7, 8
+DIFFUSE_CONCENTRATION = 0.8
+DIRECTION = NORMAL
+FADE_AT = 500
+FADE_SMOOTH = 100
+RANGE = 75
+RANGE_GRADIENT_OFFSET = 0.9
+SPECULAR_MULT = 0.8
+SPOT = 120
+SPOT_SHARPNESS = 0.1
+SPOT_EDGE = 0.5
+SPOT_EDGE_SHARPNESS = 10
+
+; ---- SMALLER SPOT LIGHTS ----------------------------------------------------
+
+[MATERIAL_ADJUSTMENT_...]
+DESCRIPTION = bridge lights
+MESHES = OBJ422_SUB1, OBJ423_SUB1, OBJ424_SUB1
+CONDITION = NIGHT_SMOOTH
+KEY_0 = ksEmissive
+VALUE_0 = 1, 1, 0.9, 256
+VALUE_0_OFF = 0
+
+[LIGHT_SERIES_...]
+DESCRIPTION = bridge lights illuminations
+MESHES = OBJ422_SUB1, OBJ423_SUB1, OBJ424_SUB1
+ACTIVE = 1
+CONDITION = NIGHT_SMOOTH
+COLOR = 1, 0.9, 0.9, 8
+DIFFUSE_CONCENTRATION = 0.8
+DIRECTION = NORMAL
+FADE_AT = 250
+FADE_SMOOTH = 100
+RANGE = 75
+RANGE_GRADIENT_OFFSET = 0.9
+SPECULAR_MULT = 0.8
+SPOT = 135
+SPOT_SHARPNESS = 0.1
+SPOT_EDGE = 0.5
+SPOT_EDGE_SHARPNESS = 10
+
+; ---- START-FINISH BUILDING --------------------------------------------------
+
+[MATERIAL_ADJUSTMENT_...]
+DESCRIPTION = start-finish building interior fluorescents
+MESHES = OBJ163_SUB0
+CONDITION = NIGHT_SHARP
+KEY_0 = ksEmissive
+VALUE_0 = 0.9, 0.85, 1.0, 256
+VALUE_0_OFF = 0
+
+[LIGHT_SERIES_...]
+DESCRIPTION = start-finish building interior fluorescents
+MESHES = OBJ163_SUB0
+ACTIVE = 1
+CONDITION = NIGHT_SHARP
+COLOR = 0.9, 0.85, 1.0, 8
+DIFFUSE_CONCENTRATION = 0.8
+DIRECTION = NORMAL
+FADE_AT = 100
+FADE_SMOOTH = 10
+RANGE = 50
+RANGE_GRADIENT_OFFSET = 0.9
+SPECULAR_MULT = 0.8
+SPOT = 90
+SPOT_SHARPNESS = 0.1
+SPOT_EDGE = 0.5
+SPOT_EDGE_SHARPNESS = 10
+
+[Material_RoomWindows]
+Materials = vitrestandsebring
+DebugMode = 0
+EmissiveMode = DIFFUSE_EMISSIVE_BLEND
+RoomHeight = 3.5
+RoomVerticalOffset = -0.7
+RoomCeilingScale = 0.25
+RoomDepth = 5.0
+EmissiveDiffuseMult = 5
+EmissiveDiffuseEXP = -2
+
+[MATERIAL_ADJUSTMENT_...]
+DESCRIPTION = start-finish building blue windows
+MATERIALS = vitrestandsebring
+CONDITION = NIGHT_SHARP
+KEY_0 = ksEmissive
+VALUE_0 = 1.0, 1.0, 0.5, 4
+VALUE_0_OFF = 0
+
+; ---- OTHER BUILDINGS --------------------------------------------------------
+[Material_RoomWindows]
+; Lexus Racing building in T1
+Materials = batlracing
+DebugMode = 0
+EmissiveMode = DIFFUSE_TEXTURE
+RoomHeight = 4.35
+RoomVerticalOffset = 1.35
+RoomCeilingScale = 0.5
+RoomDepth = 3.0
+EmissiveDiffuseMult = 5
+EmissiveDiffuseEXP = -2
+
+[MATERIAL_ADJUSTMENT_...]
+DESCRIPTION = Lexus Racing building in T1
+MATERIALS = batlracing
+CONDITION = NIGHT_SHARP
+KEY_0 = ksEmissive
+VALUE_0 = 1.0, 1.0, 0.5, 4
+VALUE_0_OFF = 0
+
+; ---- EMERGENCY VEHICLES -----------------------------------------------------
+; Note: This seems to want to appear after the Material_RoomWindows configs
+; above, so don't move it above the building sections.
+
+[CustomEmissive]
+; Ambulance emergency lights
+Materials = ambulance2
+Resolution = 1024, 1024
+; blue lights
+@ = CustomEmissive_Rect, Channel = 1, Start = "765, 88", Size = "103, 53"
+; red lights
+@ = CustomEmissive_Rect, Channel = 2, Start = "911, 88", Size = "103, 53"
+
+[MATERIAL_ADJUSTMENT_...]
+DESCRIPTION = Ambulance emergency lights
+MATERIALS = ambulance2
+ACTIVE = 1
+CONDITION = RACE_FLAG_CAUTION
+;CONDITION = ALWAYS_ON
+KEY_0 = ksEmissive1
+VALUE_0 = 0, 0.1, 1, 128
+VALUE_0_OFF = 0
+KEY_1 = ksEmissive2
+VALUE_1 = 1, 0, 0, 128
+VALUE_1_OFF = 0
+


### PR DESCRIPTION
MadBrain recently uploaded a significant improvement to his rendition of Sebring, but the lighting config didn't work well with CSP. This is intended as a replacement. It is very much a "first draft" but allows you to create a session with either layout that will work regardless of ToD.

![Example: Front Straight from Above](https://imgur.com/L44JhV5.png)
![Example: Front Straight from Pavement Level](https://imgur.com/jcCyvev.png)
![Example: Ambulance Lights](https://imgur.com/qoZUbmG.png)