### PR TITLE
hotfix: only hide nav meshes when CSP version is above 1709

### DIFF
--- a/config/cars/kunos/ks_ferrari_488_gt3.ini
+++ b/config/cars/kunos/ks_ferrari_488_gt3.ini
@@ -137,6 +137,7 @@ IS_TRANSPARENT = 1
 [SHADER_REPLACEMENT_...]
 MESHES = Extra_Mirror_SUB1
 LAYER = 10
+ACTIVE = $" read('csp/version', 0) >= 1709 "
 
 ; Create a new mirror mesh
 [INCLUDE: common/displays.ini]

--- a/config/cars/kunos/ks_ford_mustang_2015.ini
+++ b/config/cars/kunos/ks_ford_mustang_2015.ini
@@ -163,6 +163,7 @@ IS_TRANSPARENT = 0
 [SHADER_REPLACEMENT_...]
 MESHES = Geo_Nav
 LAYER = 10
+ACTIVE = $" read('csp/version', 0) >= 1709 "
 
 ; Now, create a new mesh using this template which would automatically assign digital screen shader
 ; to it as well. P1…P4 are four clockwise points on corners of the screen (had to tweak them manually


### PR DESCRIPTION
the feature does not work on >= 0.1.76, so enabling it on version below that will cause the displays to break entirely.