### PR TITLE
xbow: restore Custom Emissives

### DIFF
--- a/config/cars/kunos/ktm_xbow_r.ini
+++ b/config/cars/kunos/ktm_xbow_r.ini
@@ -1,6 +1,16 @@
 [ABOUT]
-AUTHOR=rusty
-NOTES=Added PBR
+AUTHOR=rusty, Blumlaut
+NOTES=Added PBR, Indicators
+
+[BRAKEDISC_FX]
+NORMAL_MASK = 2, 1
+CUTS = 1
+CUTS_FREQUENCY = 2
+CUTS_ASPECT_RATIO = 0.7
+CUTS_THICKNESS = 0.03
+CUTS_Y_EXP = 1
+CUTS_POINT_0 = 0.9, 0.15
+CUTS_POINT_1 = 0.1, 0.85
 
 
 [INCLUDE: common/materials_glass.ini]
@@ -30,6 +40,7 @@ Materials=Material_INT_skin
 UseClearCoat=1
 ClearCoatF0=0.25
 BrightnessAdjustment=0.3
+
 [Material_Plastic_v2]
 Materials=Material_INT_plastic_COLORS
 ColorSource=DIFFUSE
@@ -68,6 +79,41 @@ OcclusionMult=0.5
 DetailScale=0
 BrightnessAdjustment=0.5
 
+[INCLUDE: common/custom_emissive.ini]
+[CustomEmissive]
+Meshes = REAR_LIGHT_Retro
+Resolution = 256, 256
+@ = CustomEmissive_Circle, Channel = 1, Center = "231, 149.9", Size = 60, Exponent=1.5, CornerRadius="0.5,0.5"
+@ = ReverseLights, Channel = 1
+
+
+[CustomEmissive]
+Meshes = REAR_LIGHT_Position
+Resolution = 256, 256
+@ = CustomEmissive_Circle, Channel = 1, Mirror, Center = "67.8, 128.8", Size = 75, Exponent=0.8, CornerRadius="0.5,0.5"
+@ = TurningLightsRear, Channel = 1, Intensity=4, Lag=0.6
+
+[CustomEmissive]
+Meshes = car_mesh_SUB8
+Resolution = 256, 256
+@ = CustomEmissive_Poly, Channel = 1, Mirror, P1 = "165, 151", P2 = "255, 110", P3 = "255, 280", P4 = "201, 246"
+@ = TurningLightsFrontCorner, Channel = 1
+@ = CustomEmissive_Rect, Channel = 2, Mirror, Start = "2, 189", Size = "186, 66"
+@ = TurningLightsFront, Channel = 2
+
+[CustomEmissiveMulti]
+Meshes = cockpit_hr_mesh_SUB6
+Resolution = 256, 256
+UseEmissive0AsFallback = 1
+OffColor=0.2, 0.2, 0.2
+DashHighlightColor = 0.4, 0.4, 0.4
+@ = CustomEmissive_UseDiffuseLuminocity, From = 0.1, 0.12, SkipDiffuseMap = 0
+@ = DashHighlight
+@ = MultiItem, Role = TURNSIGNAL_LEFT, Start = "63, 18.9", Size = "23.5, 25.9"
+@ = MultiItem, Role = TURNSIGNAL_RIGHT, Start = "63, 18.9", Size = "23.5, 25.9"
+@ = MultiItem, Role = HANDBRAKE, Start = "147.6, 19.9", Size = "24.5, 23.6"
+
+
 [SHADER_REPLACEMENT_...]
 MATERIALS=Material_CAR_lights
 PROP_...=fresnelC,0.5
@@ -78,9 +124,19 @@ PROP_...=ksDiffuse,0.3
 PROP_...=ksSpecularEXP,1200
 PROP_...=extColoredReflection,1
 
+
 [SHADER_REPLACEMENT_...]
 MATERIALS=Material_INT_glass
 SHADER=ksWindscreenFX
+
+
+[LIGHT_LICENSEPLATE]
+OFFSET=-0.02, -0.02, -0.09
+RANGE=0.3
+RANGE_GRADIENT_OFFSET=0.5
+SPOT=180
+SPOT_SHARPNESS=0.0
+LAYOUT=TWO_ON_BOTTOM
 
 [INCLUDE: common/selflighting.ini]
 [SelfLight_Headlights]
@@ -91,6 +147,7 @@ SPOT=130
 DIFFUSE_CONCENTRATION=1
 DIRECTION=0,0.5,1
 BIND_TO_HEADLIGHTS=1
+
 [INCLUDE: common/materials_license_plate.ini]
 [Material_LicensePlate_Europe]
 


### PR DESCRIPTION
.. and some other minor things, the xbow config was entirely replaced in https://github.com/ac-custom-shaders-patch/acc-extension-config/commit/f23257df468c742414c898ad52a74a680454b701 for some reason, this merges the two configs and keeps Rusty's changes while also re-adding the custom emissives. Tested and Working.