### PR TITLE
ae86: improve sidemarkers

### DIFF
--- a/config/cars/kunos/ks_toyota_ae86.ini
+++ b/config/cars/kunos/ks_toyota_ae86.ini
@@ -109,9 +109,14 @@ Resolution=1024, 512
 @ = TurningLightsFront, Channel = 3
 
 [CustomEmissive]
-Meshes= GEO_sidelights_SUB2,GEO_sidelights_glass
+Meshes=GEO_sidelights_glass
 Resolution=1024, 512
-@ = CustomEmissive_Poly, Channel = 3, Mirror, P1 = "463.3, 416.7", P2 = "585.6, 382.2", P3 = "555, 250", P4 = "438.6, 278.6",CornerRadius = "0.8, 0.8", Exponent = 0.5
+@ = CustomEmissive_Poly, Channel = 3, Mirror, P1 = "463.3, 416.7", P2 = "585.6, 382.2", P3 = "555, 250", P4 = "438.6, 278.6", Exponent = 1.3, Sharpness = 5, Offset = 0.01
+@ = TurningLightsFrontCorner, Channel = 3, Intensity = 3
+
+[CustomEmissive]
+Meshes= GEO_sidelights_SUB2
+@ = CustomEmissive_CoverAll, Channel = 3, Mirror
 @ = TurningLightsFrontCorner, Channel = 3, Intensity = 3
 
 [CustomEmissive]


### PR DESCRIPTION
@den-88fish ~~mistakenly made the sidemarkers into indicators, the sidemarkers do not blink. this PR corrects that.~~

correction: apparently the ae86 came with indicating sidemarkers, however, the commit made them basically into blinking squares, which is ugly :(

before/after
![image](https://user-images.githubusercontent.com/13604413/148686760-0d8c835f-6d35-4cab-a31d-e494808a7b8d.png)
