### PR TITLE
Fix for missing textures in .kn5

### DIFF
--- a/config/tracks/okayama.ini
+++ b/config/tracks/okayama.ini
@@ -47,10 +47,10 @@ FILE = ?.kn5
 INSERT = okayama__buildings.kn5
 INSERT_AFTER = cone01
 
-[MODEL_REPLACEMENT_3]
-FILE = ?.kn5
-INSERT = okayama__groovereplacement.kn5
-INSERT_AFTER = Object532_SUB1
+;[MODEL_REPLACEMENT_3]
+;FILE = ?.kn5
+;INSERT = okayama__groovereplacement.kn5
+;INSERT_AFTER = Object532_SUB1
 
 [LIGHT_POLLUTION]
 RELATIVE_POSITION = -0.19, 0, 0.16


### PR DESCRIPTION
okayama__groovereplacement.kn5 calls for textures that are missing, problem is with materials "sandgp" and "sandgponly".