### PR TITLE
Tyre texture path correction C7R

### DIFF
--- a/config/cars/kunos/ks_corvette_c7r.ini
+++ b/config/cars/kunos/ks_corvette_c7r.ini
@@ -12,27 +12,28 @@ INTERIOR_FAKE_UPPER_SHADOW_FADE=0.1
 BROKEN_TYRES_BASE_NUDGE=0.1
 
 [TYRES_FX_CUSTOMTEXTURE_SS]
-TXDIFFUSE=cars\911gte\SS.dds
-TXBLUR=cars\911gte\SS_Blur.dds
+TXDIFFUSE=cars\911gte.zip::SS.dds
+TXBLUR=cars\911gte.zip::SS_Blur.dds
 
 [TYRES_FX_CUSTOMTEXTURE_S]
-TXDIFFUSE=cars\911gte\S.dds
-TXBLUR=cars\911gte\S_Blur.dds
+TXDIFFUSE=cars\911gte.zip::S.dds
+TXBLUR=cars\911gte.zip::S_Blur.dds
 
 [TYRES_FX_CUSTOMTEXTURE_M]
-TXDIFFUSE=cars\911gte\M.dds
-TXBLUR=cars\911gte\M_blur.dds
+TXDIFFUSE=cars\911gte.zip::M.dds
+TXBLUR=cars\911gte.zip::M_blur.dds
 
 [TYRES_FX_CUSTOMTEXTURE_H]
-TXDIFFUSE=cars\911gte\H.dds
-TXBLUR=cars\911gte\H_blur.dds
+TXDIFFUSE=cars\911gte.zip::H.dds
+TXBLUR=cars\911gte.zip::H_blur.dds
 
 [TYRES_FX_CUSTOMTEXTURE_SH]
-TXDIFFUSE=cars\911gte\SH.dds
-TXBLUR=cars\911gte\SH_blur.dds
+TXDIFFUSE=cars\911gte.zip::SH.dds
+TXBLUR=cars\911gte.zip::SH_blur.dds
 
 [LIGHT_EXTRA_1]
 BOUND_TO=head_lights
+BIND_TO_HEADLIGHTS=1
 COLOR=0,0,1,25
 DIFFUSE_CONCENTRATION=0.88
 EXTERIOR_ONLY=0


### PR DESCRIPTION
Tyre texture path pointing to cm auto-downloaded file instead of github folder paths.
Addition of BIND_TO_HEADLIGHTS=1 to the interior light, so it's not always casting light.