### PR TITLE
Tyre texture path correction RSR 2017

### DIFF
--- a/config/cars/kunos/ks_porsche_911_rsr_2017.ini
+++ b/config/cars/kunos/ks_porsche_911_rsr_2017.ini
@@ -24,27 +24,28 @@ ROTATION_PIVOT=0, 0.01, 0.05
 ROTATION_AXIS=-1, 0, 0
 
 [TYRES_FX_CUSTOMTEXTURE_SS]
-TXDIFFUSE=cars\911gte\SS.dds
-TXBLUR=cars\911gte\SS_Blur.dds
+TXDIFFUSE=cars\911gte.zip::SS.dds
+TXBLUR=cars\911gte.zip::SS_Blur.dds
 
 [TYRES_FX_CUSTOMTEXTURE_S]
-TXDIFFUSE=cars\911gte\S.dds
-TXBLUR=cars\911gte\S_Blur.dds
+TXDIFFUSE=cars\911gte.zip::S.dds
+TXBLUR=cars\911gte.zip::S_Blur.dds
 
 [TYRES_FX_CUSTOMTEXTURE_M]
-TXDIFFUSE=cars\911gte\M.dds
-TXBLUR=cars\911gte\M_blur.dds
+TXDIFFUSE=cars\911gte.zip::M.dds
+TXBLUR=cars\911gte.zip::M_blur.dds
 
 [TYRES_FX_CUSTOMTEXTURE_H]
-TXDIFFUSE=cars\911gte\H.dds
-TXBLUR=cars\911gte\H_blur.dds
+TXDIFFUSE=cars\911gte.zip::H.dds
+TXBLUR=cars\911gte.zip::H_blur.dds
 
 [TYRES_FX_CUSTOMTEXTURE_SH]
-TXDIFFUSE=cars\911gte\SH.dds
-TXBLUR=cars\911gte\SH_blur.dds
+TXDIFFUSE=cars\911gte.zip::SH.dds
+TXBLUR=cars\911gte.zip::SH_blur.dds
 
 [LIGHT_EXTRA_1]
 BOUND_TO=head_lights
+BIND_TO_HEADLIGHTS=1
 COLOR=2,0,2.5,6
 DIFFUSE_CONCENTRATION=0.88
 EXTERIOR_ONLY=0


### PR DESCRIPTION
Tyre texture path pointing to cm auto-downloaded file instead of github folder paths.
Addition of BIND_TO_HEADLIGHTS=1 to the interior light, so it's not always casting light.