### PR TITLE
Tyre textures path fix to .zip on Audi R8 LMS + Ultra and gt3_tyres_kunos.ini

### DIFF
--- a/config/cars/common/gt3_tyres_kunos.ini
+++ b/config/cars/common/gt3_tyres_kunos.ini
@@ -1,11 +1,11 @@
 [TYRES_FX_CUSTOMTEXTURE_S]
-TXDIFFUSE=cars\ks_mercedes_amg_gt3\S.dds
-TXBLUR=cars\ks_mercedes_amg_gt3\S_Blur.dds
+TXDIFFUSE=cars\ks_mercedes_amg_gt3.zip::S.dds
+TXBLUR=cars\ks_mercedes_amg_gt3.zip::S_Blur.dds
 
 [TYRES_FX_CUSTOMTEXTURE_M]
-TXDIFFUSE=cars\ks_mercedes_amg_gt3\M.dds
-TXBLUR=cars\ks_mercedes_amg_gt3\M_blur.dds
+TXDIFFUSE=cars\ks_mercedes_amg_gt3.zip::M.dds
+TXBLUR=cars\ks_mercedes_amg_gt3.zip::M_blur.dds
 
 [TYRES_FX_CUSTOMTEXTURE_H]
-TXDIFFUSE=cars\ks_mercedes_amg_gt3\H.dds
-TXBLUR=cars\ks_mercedes_amg_gt3\H_blur.dds
+TXDIFFUSE=cars\ks_mercedes_amg_gt3.zip::H.dds
+TXBLUR=cars\ks_mercedes_amg_gt3.zip::H_blur.dds

--- a/config/cars/kunos/ks_audi_r8_lms.ini
+++ b/config/cars/kunos/ks_audi_r8_lms.ini
@@ -9,16 +9,16 @@ INTERIOR_FAKE_UPPER_SHADOW_HEIGHT=-0.05
 INTERIOR_FAKE_UPPER_SHADOW_FADE=0.1
 
 [TYRES_FX_CUSTOMTEXTURE_S]
-TXDIFFUSE=cars\ks_mercedes_amg_gt3\S.dds
-TXBLUR=cars\ks_mercedes_amg_gt3\S_Blur.dds
+TXDIFFUSE=cars\ks_mercedes_amg_gt3.zip::S.dds
+TXBLUR=cars\ks_mercedes_amg_gt3.zip::S_Blur.dds
 
 [TYRES_FX_CUSTOMTEXTURE_M]
-TXDIFFUSE=cars\ks_mercedes_amg_gt3\M.dds
-TXBLUR=cars\ks_mercedes_amg_gt3\M_blur.dds
+TXDIFFUSE=cars\ks_mercedes_amg_gt3.zip::M.dds
+TXBLUR=cars\ks_mercedes_amg_gt3.zip::M_blur.dds
 
 [TYRES_FX_CUSTOMTEXTURE_H]
-TXDIFFUSE=cars\ks_mercedes_amg_gt3\H.dds
-TXBLUR=cars\ks_mercedes_amg_gt3\H_blur.dds
+TXDIFFUSE=cars\ks_mercedes_amg_gt3.zip::H.dds
+TXBLUR=cars\ks_mercedes_amg_gt3.zip::H_blur.dds
 
 [LIGHT_EXTRA_1]
 BOUND_TO=head_lights

--- a/config/cars/kunos/ks_audi_r8_lms_2016.ini
+++ b/config/cars/kunos/ks_audi_r8_lms_2016.ini
@@ -18,16 +18,16 @@ ROTATION_PIVOT=0, 0.0, -0.035
 ROTATION_AXIS=-1, 0, 0
 
 [TYRES_FX_CUSTOMTEXTURE_S]
-TXDIFFUSE=cars\ks_mercedes_amg_gt3\S.dds
+TXDIFFUSE=cars\ks_mercedes_amg_gt3.zip::S.dds
 TXBLUR=cars\ks_mercedes_amg_gt3\S_Blur.dds
 
 [TYRES_FX_CUSTOMTEXTURE_M]
-TXDIFFUSE=cars\ks_mercedes_amg_gt3\M.dds
-TXBLUR=cars\ks_mercedes_amg_gt3\M_blur.dds
+TXDIFFUSE=cars\ks_mercedes_amg_gt3.zip::M.dds
+TXBLUR=cars\ks_mercedes_amg_gt3.zip::M_blur.dds
 
 [TYRES_FX_CUSTOMTEXTURE_H]
-TXDIFFUSE=cars\ks_mercedes_amg_gt3\H.dds
-TXBLUR=cars\ks_mercedes_amg_gt3\H_blur.dds
+TXDIFFUSE=cars\ks_mercedes_amg_gt3.zip::H.dds
+TXBLUR=cars\ks_mercedes_amg_gt3.zip::H_blur.dds
 
 [LIGHT_EXTRA_1]
 BOUND_TO=head_lights


### PR DESCRIPTION
Now it fits the CM auto download location of the .zip.
Old path pointed at subfolder \ks_mercedes_amg_gt3\ which does not exist -> many support requests "help, my tyres on GTs are black"