### PR TITLE
Update bo_caterham_s7_1700_ss_clamshell.ini

### DIFF
--- a/config/cars/mods/bo/bo_caterham_s7_1700_ss_clamshell.ini
+++ b/config/cars/mods/bo/bo_caterham_s7_1700_ss_clamshell.ini
@@ -72,3 +72,7 @@ MOVEMENT_INTERVAL = 1
 ; DynamicReflections = 1
 ; SplitInModelSpace = 1
 ; ExcludeNodes = COCKPIT_HR, wing_r?, HUB_LR, HUB_RR, taillight?, boot_cover, engine_bloc, MASK_light, mainlight glass, chassis001, dash_dust, susp_rear?
+
+[NODE_ADJUSTMENT_...]
+NODES = ARROW_?, logos_dash_emissive
+MOVE_TO = COCKPIT_HR

--- a/config/cars/mods/bo/bo_caterham_s7_1700_ss_clamshell.ini
+++ b/config/cars/mods/bo/bo_caterham_s7_1700_ss_clamshell.ini
@@ -74,5 +74,10 @@ MOVEMENT_INTERVAL = 1
 ; ExcludeNodes = COCKPIT_HR, wing_r?, HUB_LR, HUB_RR, taillight?, boot_cover, engine_bloc, MASK_light, mainlight glass, chassis001, dash_dust, susp_rear?
 
 [NODE_ADJUSTMENT_...]
-NODES = ARROW_?, logos_dash_emissive
+NODES = ARROW_?
 MOVE_TO = COCKPIT_HR
+
+[EMISSIVE_LIGHT_...]
+NAME = logos_dash_emissive
+COLOR = 0.1,0.5,0.1
+


### PR DESCRIPTION
Prevent emissives outside COCKPIT_HR going nuclear

Note: I've done a second commit that keeps logos_dash_emissive outside COCKPIT_HR, but still enforce its original lights.ini values via config. By this way, the mesh won't disappear in the HR>LR transition, which can be noticeable and look different in behavior to the LHD/RHD variants.