### PR TITLE
Update config ks_toyota_gt86.ini

### DIFF
--- a/config/cars/kunos/ks_toyota_gt86.ini
+++ b/config/cars/kunos/ks_toyota_gt86.ini
@@ -178,12 +178,23 @@ CarPaintMaterial = Body
 CarPaintVersionAware = 4
 DisableDev = 1
 
+[Material_CarPaint_Solid]
+Skins = lightning_red, rsrnurburg, vivid_yellow
+FresnelMax = 0.5
+FresnelC = 0.08
+AmbientSpecular = 0.3
+SpecularBase = 0.2, 100
+ClearCoatThickness = 0.04
+
 [Material_CarPaint_Metallic]
-; BrightnessAdjustment = 0.5
-; SpecularBase = 2, 10
-; SpecularSun = 10, 1000
-; FresnelMax = 1
-; FresnelC = 0.4
+Skins = 0_fusion_orange, crystal_black, crystal_white_pearl, dark_grey, galaxy_blue, gravity_blue, ice_silver, ignition_red, velocity_orange
+FresnelMax = 1
+FresnelC = 0.1
+BrightnessAdjustment = 0.9 ; compensates for ambient specular
+ColoredSpecular = 0.9
+AmbientSpecular = 0.6
+AmbientSpecularEXP = 2.5
+ClearCoatThickness = 0.06
 
 ; Glass with mask pass for tint
 [INCLUDE: common/materials_glass.ini]


### PR DESCRIPTION
- Changed car paint values, differentiating between solid and metallic colors (using materials_carpaint.ini templates by gro-ove, found in this github).
- First screenshot is an example of solid color (Lightning Red).
- Second screenshot is an example of metallic color (Fusion Orange).

![Screenshot_ks_toyota_gt86_magione_11-3-123-11-40-50](https://user-images.githubusercontent.com/129396680/231122825-394c5b04-28ca-409d-83af-b3f15be10893.png)
![Screenshot_ks_toyota_gt86_magione_11-3-123-11-40-20](https://user-images.githubusercontent.com/129396680/231123153-61bdc562-950d-4706-8b95-bcd654b09fb0.png)
