### PR TITLE
Kunos/ks_ferrari_488_gtb.ini - Turns, Hazards, Reverse Lights

### DIFF
--- a/config/cars/kunos/ks_ferrari_488_gtb.ini
+++ b/config/cars/kunos/ks_ferrari_488_gtb.ini
@@ -62,3 +62,19 @@ FilmIOR = 2.5
 
 [INCLUDE: common/materials_license_plate.ini]
 [Material_LicensePlate_Europe]
+
+[CustomEmissive]
+Meshes = LIGHT_F_light
+MirrorDir = 1,0,0
+@MIXIN = CustomEmissive_Color, Channel = 3, Mirror, "Color = 0.5, 0.5, 0.5"
+@MIXIN = TurningLights, Channel = 3, "Color = 1,0.33,0", Intensity = 50
+
+[CustomEmissive]
+Meshes = LIGHT_R_position
+MirrorDir = 1,0,0
+@MIXIN = CustomEmissive_Color, Channel = 3, Mirror, "Color = 1, 0, 0"
+@MIXIN = TurningLights, Channel = 3, "Color = 15,100,0", Intensity = 5
+@MIXIN = CustomEmissive_Color, Channel = 0, "Color = 1, 0, 0"
+@MIXIN = BrakingLights, Channel = 0, Intensity = 15
+@MIXIN = CustomEmissive_Color, Channel = 1, "Color = 1, 0, 0"
+@MIXIN = ReverseLights, Channel = 1, "Color = 0.1,1,1", Intensity = 2000


### PR DESCRIPTION
https://www.youtube.com/watch?v=UcDWYd6dleI
-
I believe on the real 488 gtb that the reverse lights are clustered inside the black part, but these are not modeled in the game; so I put the reverse light stacked with brakes and hazards. -
I had a look through the other cars, there doesn't seem to be any consistency about which channel to use for reverse lights so i picked channel 1.