### PR TITLE
ks_mazda_miata.ini / Fixing Main Beam

### DIFF
--- a/config/cars/kunos/ks_mazda_miata.ini
+++ b/config/cars/kunos/ks_mazda_miata.ini
@@ -6,8 +6,8 @@ SKIP_GBUFFER = material:int_glass
 
 [LIGHT_HEADLIGHT_0]
 COLOR=10,10,8,2
-SPOT=60
-RANGE=40
+SPOT=70
+RANGE=150
 
 ; other stuff
 [BRAKEDISC_FX]


### PR DESCRIPTION
Giving the miata more realistic main beam so you can actually see the road ahead of you at night. Spot matches the conal shape of the dipped headlights.

https://www.youtube.com/watch?v=LWklk7FTk3s