### PR TITLE
Address night bugs: pau_2017.ini

### DIFF
--- a/config/tracks/pau_2017.ini
+++ b/config/tracks/pau_2017.ini
@@ -570,6 +570,20 @@ OFF_VALUE_0 = -193
 ACTIVE = 1
 DESCRIPTION = tiling fix
 
+[MATERIAL_ADJUSTMENT_12]
+MATERIALS = pub_buisson1
+KEY_0 = ksDiffuse
+VALUE_0 = 0.25
+ACTIVE = 1
+DESCRIPTION = one glowing billboard fix
+
+[MATERIAL_ADJUSTMENT_13]
+MATERIALS = BKA
+KEY_0 = ksAmbient
+VALUE_0 = 0.3
+ACTIVE = 1
+DESCRIPTION = bright mountains at night fix
+
 [LIGHT_0]
 DESCRIPTION = hotel line light
 ACTIVE = 1


### PR DESCRIPTION
Two bugs in this track are only really noticeable at night, but then are highly obvious:

1. Pyrenees Mountains texture in the distance is lit up like day time.
2. One billboard has a `ksDiffuse` value of 25, causing a nuclear glow; clearly a typo since the two billboards immediately beside it are set to 0.25 and look fine.

<details><summary>Expand for before/after Screenshots of 2pm, 7pm, midnight at the summer solstice</summary>

### Before 

![2pm without fix](https://github.com/ac-custom-shaders-patch/acc-extension-config/assets/77416784/1ea2ad8a-91a6-401d-8716-352612fc3bd7)

![7pm without fix](https://github.com/ac-custom-shaders-patch/acc-extension-config/assets/77416784/dc63ddac-357d-4d08-abf7-8946fbe3cc21)

![12am without fix](https://github.com/ac-custom-shaders-patch/acc-extension-config/assets/77416784/739e46bd-02a3-44c1-b1ec-6e28e2424ebd)

### After

![2pm with fix](https://github.com/ac-custom-shaders-patch/acc-extension-config/assets/77416784/87976f11-733c-4f81-b792-fada75780d98)

![7pm with fix](https://github.com/ac-custom-shaders-patch/acc-extension-config/assets/77416784/b0712c0a-a014-44f8-8635-02683d61ca8f)

![12am with fix](https://github.com/ac-custom-shaders-patch/acc-extension-config/assets/77416784/fb654821-b1a7-40f4-aab8-a8bd01b37953)


</details>