### PR TITLE
Fixed wrong sekia hills naming

### DIFF
--- a/config/data_track_params.ini
+++ b/config/data_track_params.ini
@@ -2542,8 +2542,8 @@ LATITUDE=30.68630
 LONGITUDE=-86.79146
 TIMEZONE=America/Chicago
 
-[Sekia Hills]
-NAME=pt_sekia_hills
+[pt_sekia_hills]
+NAME=Sekia Hills
 LATITUDE=33.0573046
 LONGITUDE=130.5230922
 TIMEZONE=Japan


### PR DESCRIPTION
Did an mistake with the naming. Name was set to 'pt_sekia_hills' instead of 'Sekia Hills'.