### PR TITLE
Update ks_mazda_mx5_cup.ini

### DIFF
--- a/config/cars/kunos/ks_mazda_mx5_cup.ini
+++ b/config/cars/kunos/ks_mazda_mx5_cup.ini
@@ -2,11 +2,18 @@
 INCLUDE=common/no_popup_lights.ini
 
 [LIGHTING]
+EMISSIVE_HEADLIGHTS_MULT=1
+EMISSIVE_PARKINGLIGHTS_MULT=1
+EMISSIVE_BRAKELIGHTS_MULT=1
 INTERIOR_FAKE_SHADOW_OPACITY=0.9
 INTERIOR_FAKE_SHADOW_HEIGHT=0.4
 INTERIOR_FAKE_SHADOW_FADE=0.5
 INTERIOR_FAKE_UPPER_SHADOW_HEIGHT=-0.05
 INTERIOR_FAKE_UPPER_SHADOW_FADE=0.1
+
+[LIGHT_BRAKES]
+BOUND_EMISSIVE_MAX=10000
+BOUND_EXP=3
 
 [DEFORMING_HOOD]
 NAME=MOTOR_HOOD
@@ -23,6 +30,39 @@ NOISE_OFFSET=-2
 Z_FACTOR=2.5
 Z_BIAS=0.15
 
+; New car paint
+[INCLUDE: common/materials_carpaint.ini]
+CarPaintMaterial = EXT_Carpaint, INT_OCC_Carpaint
+CarPaintVersionAware = 4
+
+[Material_CarPaint_Solid]
+Skins = 01_cup_07, 06_cup_55, 07_cup_56, 12_cup_62, 13_cup_70, 14_cup_87
+FresnelMax = 0.5
+FresnelC = 0.08
+AmbientSpecular = 0.3
+SpecularBase = 0.2, 100
+ClearCoatThickness = 0.03
+
+[Material_CarPaint_Metallic]
+Skins = 00_official, 02_cup_23, 03_cup_24, 04_cup_29, 05_cup_36, 08_cup_57, 09_cup_58, 10_cup_60, 11_cup_61, 15_speedsource_71, 17_arisoil_72
+FresnelMax = 1
+FresnelC = 0.1
+BrightnessAdjustment = 0.9 ; compensates for ambient specular
+ColoredSpecular = 0.9
+AmbientSpecular = 0.6
+AmbientSpecularEXP = 2.5
+ClearCoatThickness = 0.06
+
+;New rim paint
+CarPaintMaterial = EXT_Rim
+CarPaintVersionAware = 4
+
+[Material_CarPaint_Solid]
+FresnelMax = 0.5
+FresnelC = 0.08
+AmbientSpecular = 0.3
+SpecularBase = 0.2, 100
+ClearCoatThickness = 0.03
 
 [INCLUDE: common/custom_emissive.ini]
 
@@ -220,3 +260,26 @@ RANGE=0.6
 SPOT=100
 BIND_TO_HEADLIGHTS=1
 MIRROR=0.61 ; first value
+
+[PARTICLES_FX_EXHAUST_0]
+POSITION=-0.295, 0.250, -1.90
+DIRECTION=-0.1,0.125,-1		; self explanatory
+COLOR = 0.75,0.8,1 			; RGB blend - 0,0,0 is black, 1,1,1 is white
+LIFE = 1, 2 				; how long particles last in the air before disappearing
+SPEED = 0.5, 1 				; how fast smoke particles fly from the exhaust
+SPREAD = 0.25				; initial spread of particles
+STARTING_SIZE = 0.04			; initial size of particles
+SPAWN_OFFSET = 0.02			; initial spawn point offset (length-wise)
+INTENSITY = 0.030, 0.06			; smoke intensity
+TEMPERATURE_LAG = 1 			; engine heating up (1 to disable)
+SPEED_THRESHOLD = 15, 100 		; speed at which the smoke disappears
+
+[SHAKING_EXHAUST_...]
+MESHES = polymsh_detached67
+POINT_0 = -0.295, 0.250, -1.80
+POINT_0_RADIUS = 0.12
+POINT_0_EXP = 1.0
+POINT_0_SCALE = 0.12
+
+[ODOMETER_TRIP]
+DIGITAL_ITEM=1


### PR DESCRIPTION
· Edited [LIGHTING], to be inline with the Mazda MX5 ND 
 ext_config.
· Added [LIGHT_BRAKES], to be inline with the Mazda MX5 ND 
 ext_config.
· Changed car paint values, differentiating between solid and 
  metallic colors (using materials_carpaint.ini templates by gro- 
  ove, found in this github).
· Added exhaust smoke.
· Added shaking exhaust.
· Activated Odometer_Trip.

![Screenshot_ks_mazda_mx5_cup_magione_29-8-124-13-8-16](https://github.com/user-attachments/assets/d71f291a-da83-4175-8dd1-1bdac1bfb7b7)
![Screenshot_ks_mazda_mx5_cup_magione_29-8-124-13-8-29](https://github.com/user-attachments/assets/7dd7da46-3ebd-4c62-8b25-359cfc0a4899)
![Screenshot_ks_mazda_mx5_cup_magione_29-8-124-13-8-45](https://github.com/user-attachments/assets/7473737a-08d9-46ea-9b6e-2407d77c3c27)
![Screenshot_ks_mazda_mx5_cup_magione_29-8-124-13-9-4](https://github.com/user-attachments/assets/b14746b8-5094-4529-ac27-7533b26ecee8)
![Screenshot_ks_mazda_mx5_cup_magione_29-8-124-13-9-26](https://github.com/user-attachments/assets/3a2c597a-2795-4eb3-b028-c709477bfdff)
![Screenshot_ks_mazda_mx5_cup_magione_29-8-124-13-9-33](https://github.com/user-attachments/assets/03530064-5e02-4d22-93dd-53bb1ee9c111)
![Screenshot_ks_mazda_mx5_cup_magione_29-8-124-13-9-40](https://github.com/user-attachments/assets/2cda761f-da6b-416d-83cc-fd16690dfc37)
![Screenshot_ks_mazda_mx5_cup_magione_29-8-124-13-9-53](https://github.com/user-attachments/assets/90df720d-d90c-4128-a399-60e7cf615c52)
![Screenshot_ks_mazda_mx5_cup_magione_29-8-124-13-14-3](https://github.com/user-attachments/assets/22690527-6f6f-4763-ab73-c26d44cbfbf7)
![Screenshot_ks_mazda_mx5_cup_magione_29-8-124-13-14-13](https://github.com/user-attachments/assets/f3331869-ea25-4ab6-b0c7-70797260c131)
![Screenshot_ks_mazda_mx5_cup_magione_29-8-124-13-37-48](https://github.com/user-attachments/assets/e607d13a-1991-4bdd-9cda-0f3c0e37e3c1)
![Screenshot_ks_mazda_mx5_cup_magione_29-8-124-13-38-27](https://github.com/user-attachments/assets/8805ec0a-d8ee-4e33-97d4-7142749a4ccb)
