### PR TITLE
Bremgarten and Battenbergring TZ and geo data

### DIFF
--- a/config/data_track_params.ini
+++ b/config/data_track_params.ini
@@ -343,6 +343,12 @@ LONGITUDE=147.3272
 TIMEZONE=Australia/Hobart
 NAME=Baskerville
 
+[battenbergring]
+LATITUDE=50.974
+LONGITUDE=8.608
+TIMEZONE=Europe/Berlin
+NAME=Battenbergring
+
 [battersea]
 LATITUDE=51.506401
 LONGITUDE=-0.12721
@@ -380,6 +386,12 @@ LATITUDE=52.19025
 LONGITUDE=8.18436
 TIMEZONE=Europe/Berlin
 NAME=Borgloh
+
+[bremgarten]
+LATITUDE=46.95
+LONGITUDE=7.410833
+TIMEZONE=Europe/Zurich
+NAME=Bremgarten
 
 [bridgehampton]
 HEADING_ANGLE=0


### PR DESCRIPTION
This completes entries for Fat-Alfie's released tracks to date.

Data sources: 
* [Battenbergring](https://geohack.toolforge.org/geohack.php?pagename=Battenbergring&language=de&params=50.974_N_8.608_E_dim:250_region:DE-HE_type:building&title=Battenbergring)
* [Bremgarten](https://geohack.toolforge.org/geohack.php?pagename=Circuit_Bremgarten&params=46_57_00_N_7_24_39_E_type:landmark_region:CH-BE)