### PR TITLE
Update ks_nurburgring.ini

### DIFF
--- a/config/tracks/ks_nurburgring.ini
+++ b/config/tracks/ks_nurburgring.ini
@@ -1,5 +1,5 @@
 [ABOUT]
-AUTHOR = Benner900, Peter Boese (seasons), leBluem, gunnar333
+AUTHOR = Benner900, Peter Boese (seasons), leBluem, gunnar333, Linus-Britto
 VERSION = 1.5
 DATE_RELEASE = 15 july 2024
 LIGHTS_COUNT = 159/201/252
@@ -691,8 +691,45 @@ INSERT_AFTER = Object45
  ;Material Replacement
  ;------------
 
+[Material_RoomWindows] ;box-alpha-spec
+Meshes= Cylinder06
+RoomHeight = 5         
+RoomVerticalOffset = 2
+RoomDepth = 8.0
+RoomNearEdgeClipping = 3.0                          
+RoomCeilingScale = 0.3                   
+Shape1_X_W = 0.07
+Shape1_Y_W = 0.07
+Shape2_X_Mult = 0
+ShapeChance = 1
+NormalsFactor = 0.3 
+
+[Material_RoomWindows] ;Pitglass
+Meshes = nurbpitglass2
+RoomHeight = 5
+RoomVerticalOffset = 0.8
+RoomDepth = 6
+RoomNearEdgeClipping = 2.0 
+RoomCeilingScale = 0.3                   
+Shape1_X_W = 0.15
+Shape1_Y_W = 0.15
+InteriorBaseBrightness = 1.5
+
+[Material_RoomWindows] ;GlassLarge
+Meshes= nurbglasslarge
+RoomHeight = 3.9          
+RoomVerticalOffset = 2.8
+RoomDepth = 10.0
+RoomNearEdgeClipping = 1.0                          
+RoomCeilingScale = 0.3                   
+Shape1_X_W = 0.07
+Shape1_Y_W = 0.07
+Shape2_X_Mult = 0
+ShapeChance = 1
+NormalsFactor = 0.2
+
 [Material_DistantEmissive]
-Materials= LightEmssive?
+Materials= LightEmissive, LightEmssivePad
 DotRadiusMult_v2=1
 DotBrightnessMult_v2=2
 DotBrightnessCenter_v2=1
@@ -722,7 +759,7 @@ MATERIALS = box-alpha-spec
 CONDITION = NIGHT_SMOOTH
 KEY_0 = ksEmissive
 VALUE_0 = 1, 0.71, 0.42,6
-VALUE_0_OFF = 0, 0, 0
+VALUE_0_OFF = 1, 0.71, 0.42,1
 ACTIVE = 1
 
 [MATERIAL_ADJUSTMENT_3]
@@ -739,7 +776,7 @@ ACTIVE = 1
 MATERIALS = PitGlass
 CONDITION = NIGHT_SMOOTH
 KEY_0 = ksEmissive
-VALUE_0 = 1, 0.7, 0.5,30
+VALUE_0 = 1, 0.7, 0.5,10
 VALUE_0_OFF = 0, 0, 0
 ACTIVE = 1
 
@@ -749,7 +786,7 @@ MATERIALS = GlassLarge
 CONDITION = NIGHT_SMOOTH
 KEY_0 = ksEmissive
 VALUE_0 = 1, 0.7, 0.5,5
-VALUE_0_OFF = 0, 0, 0
+VALUE_0_OFF = 1, 0.7, 0.5,1
 ACTIVE = 1
 
 [LIGHT_SERIES_34]
@@ -1085,9 +1122,10 @@ CONDITION=NIGHT_SMOOTH
 ;MOVE_MESH_BEHIND = parent:modelRoot:y
 
 [SHADER_REPLACEMENT_...]
-MESHES = Cylinder06
+MESHES = Cylinder06, nurbglasslarge
 IS_TRANSPARENT = 1
 DEPTH_MODE = NORMAL_FORCED
+PROP_... = extBrightnessAmbientVolume, 0
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;Adds new 2022 objects
@@ -1135,3 +1173,11 @@ RESOURCE_2=txMaps
 RESOURCE_TEXTURE_2=gstands2_MAP.dds
 RESOURCE_3=txDetail
 RESOURCE_TEXTURE_3=gstands2_MAP.dds
+
+[MATERIAL_ADJUSTMENT_...];change
+ACTIVE=1
+DESCRIPTION= Mercedes Logo Emissive
+MESHES= Torus001
+KEY_0=ksEmissive
+VALUE_0=255,255,255,0.05
+CONDITION=NIGHT_SMOOTH


### PR DESCRIPTION
Just like my Nordschleife patch from a couple of days ago, I have introduced updates for the standalone GP version of the track as well.

Added Mercedes Logo emissive in GP.

Added room window lights in GP pits.

Fixed my previous code for distant emissive to include all emissive lights.

![20241207072234_1](https://github.com/user-attachments/assets/7a3e953a-94b2-466f-b5a0-8bbb25b21fdd)

![20241207072159_1](https://github.com/user-attachments/assets/1a5fb7b7-3e9e-4999-8c79-a729181c31ed)

![20241207072143_1](https://github.com/user-attachments/assets/cbbccdf5-7ea9-4b67-9b05-ee81188e1b34)

