### PR TITLE
fix: handbrake indicator restored

### DIFF
--- a/config/cars/kunos/ks_audi_sport_quattro.ini
+++ b/config/cars/kunos/ks_audi_sport_quattro.ini
@@ -117,7 +117,7 @@ Resolution = 1024, 1024
 UseEmissive0AsFallback = 1
 @ = MultiItem, Role = DashWarningABS, Start = "857.4, 961.5", Size = "81.4, 52.1"
 @ = MultiItem, Role = ENGINE_LIFE, InputThreshold = 400, InputInverse, Start = "856.4, 843.5", Size = "81.2, 54.1"
-@ = MultiItem, Role = HANDBRAKE, Start = "585.1, 62.9", Size = "33.6, 29.2"
+@ = MultiItem, Input = HANDBRAKE, Start = "773.4, 961.5", Size = "81.2, 54.1"
 @ = MultiItem, Input = HIGHBEAM, Start = "773.3, 844.1", Size = "78.7, 51.6"
 
 [CustomEmissive]


### PR DESCRIPTION
Little fix for Audi Sport quattro handbrake indicator position
![Screenshot_7](https://github.com/user-attachments/assets/801da54e-d37f-40b6-ba3d-5f0c3b7e8c69)
