### PR TITLE
fix: remove SUB5 from rear indicators on Porsche Boxter S

### DIFF
--- a/config/cars/kunos/ks_porsche_718_boxster_s.ini
+++ b/config/cars/kunos/ks_porsche_718_boxster_s.ini
@@ -39,7 +39,7 @@ Resolution = 1024, 512
 @ = MultiItem, Role = HAZARD, Start = "158, 246", Size = "52, 33"
 
 [CustomEmissive]
-Meshes = GEO_Chassis_SUB5, GEO_Chassis_SUB6
+Meshes = GEO_Chassis_SUB6
 Resolution = 1024, 1024
 @ = CustomEmissive_Rect, Channel = 1, Mirror, Start = "5, 865", Size = "515, 23"
 @ = TurningLightsRear, Channel = 1, Lag = 0


### PR DESCRIPTION
not sure why this was here, it would light up the soft top when indicating