### PR TITLE
Fix Audio R8 LMS windshield texture visual glitch

### DIFF
--- a/config/cars/kunos/ks_audi_r8_lms.ini
+++ b/config/cars/kunos/ks_audi_r8_lms.ini
@@ -47,7 +47,6 @@ SPOT_SHARPNESS=0.5
 [Material_WindscreenBanner]
 Materials = EXT_Glass_Logo_INT
 CastShadowsThreshold = 0.99
-MOVE_MESH_IN_FRONT_OF = parent:COCKPIT_HR
 
 ; [SHADER_REPLACEMENT_...]
 ; MATERIALS = EXT_Glass_Logo_INT
@@ -61,3 +60,4 @@ NAME= RearLights_2
 BLINKING_PATTERN= (|0=0|0.499=0.0|0.5=1|1=1|)
 BLINKING_DURATION=0.4
 COLOR=1,0,0,45
+


### PR DESCRIPTION
There’s an issue with the Audi R8 LMS windshield texture: it takes ages to load and appears heavily glitched. Removing this line fixes the problem, although I’m not entirely sure it’s the best solution.

<img width="2560" height="1440" alt="Screenshot (145)" src="https://github.com/user-attachments/assets/ae138ca8-f4c9-419c-914d-7172be0af1f3" />
